### PR TITLE
Conda environments

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,3 +24,4 @@ build_script:
 
 test_script:
   - C:\projects\julia\bin\julia --check-bounds=yes -e "ENV[\"HOME\"]=joinpath(homedir(),\"Conda test home\"); Pkg.test(\"Conda\")"
+

--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -1,2 +1,3 @@
 usr/
+deps.jl
 !.gitignore

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,4 @@
+default_dir = get(ENV, "CONDA_JL_HOME", abspath(dirname(@__FILE__), "usr"))
+open("deps.jl", "w") do f
+    println(f, "default_dir=\"$default_dir\"")
+end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -13,3 +13,8 @@ deps = "const ROOTENV=\"$(escape_string(ROOTENV))\"\n"
 if !isfile("deps.jl") || readstring("deps.jl") != deps
     write("deps.jl", deps)
 end
+
+if !isdir(ROOTENV)
+    # Ensure ROOTENV exists, otherwise prefix(ROOTENV) will throw
+    mkpath(ROOTENV)
+end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,4 @@
-default_dir = get(ENV, "CONDA_JL_HOME", abspath(dirname(@__FILE__), "usr"))
+default_dir = get(ENV, "CONDA_JL_HOME", abspath(joinpath(dirname(@__FILE__), "usr")))
 open("deps.jl", "w") do f
-    println(f, "default_dir=\"$default_dir\"")
+    println(f, "default_dir=\"$(escape_string(default_dir))\"")
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,15 +1,15 @@
+using Compat
+
 if haskey(ENV, "CONDA_JL_HOME")
-    default_dir = ENV["CONDA_JL_HOME"]
+    rootenv = ENV["CONDA_JL_HOME"]
 elseif isfile("deps.jl")
     include("deps.jl")
 else
-    default_dir = abspath(dirname(@__FILE__), "usr")
+    rootenv = abspath(dirname(@__FILE__), "usr")
 end
 
-deps = "default_dir=\"$(escape_string(default_dir))\""
+deps = "rootenv=\"$(escape_string(rootenv))\""
 
-if !isfile("deps.jl") || readchomp("deps.jl") != deps
-    open("deps.jl", "w") do f
-        println(f, deps)
-    end
+if !isfile("deps.jl") || Compat.readstring("deps.jl") != deps
+    write("deps.jl", deps)
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,15 @@
-default_dir = get(ENV, "CONDA_JL_HOME", abspath(joinpath(dirname(@__FILE__), "usr")))
-open("deps.jl", "w") do f
-    println(f, "default_dir=\"$(escape_string(default_dir))\"")
+if haskey(ENV, "CONDA_JL_HOME")
+    default_dir = ENV["CONDA_JL_HOME"]
+elseif isfile("deps.jl")
+    include("deps.jl")
+else
+    default_dir = abspath(dirname(@__FILE__), "usr")
+end
+
+deps = "default_dir=\"$(escape_string(default_dir))\""
+
+if !isfile("deps.jl") || readchomp("deps.jl") != deps
+    open("deps.jl", "w") do f
+        println(f, deps)
+    end
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,15 +1,15 @@
 using Compat
 
 if haskey(ENV, "CONDA_JL_HOME")
-    rootenv = ENV["CONDA_JL_HOME"]
+    ROOTENV = ENV["CONDA_JL_HOME"]
 elseif isfile("deps.jl")
     include("deps.jl")
 else
-    rootenv = abspath(dirname(@__FILE__), "usr")
+    ROOTENV = abspath(dirname(@__FILE__), "usr")
 end
 
-deps = "rootenv=\"$(escape_string(rootenv))\""
+deps = "const ROOTENV=\"$(escape_string(ROOTENV))\"\n"
 
-if !isfile("deps.jl") || Compat.readstring("deps.jl") != deps
+if !isfile("deps.jl") || readstring("deps.jl") != deps
     write("deps.jl", deps)
 end

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -71,6 +71,12 @@ function bin_dir(env::Environment)
 end
 const BINDIR = bin_dir(RootEnv)
 
+"Prefix for the shared libraries installed with the packages"
+function bin_dir(env::Environment)
+    return is_windows() ? joinpath(prefix(env), "Library", "bin") : joinpath(prefix(env), "lib")
+end
+const LIBDIR = lib_dir(RootEnv)
+
 "Prefix for the python scripts. On UNIX, this is the same than Conda.BINDIR"
 function scriptdir(env::Environment)
     return is_windows() ? joinpath(prefix(env), "Scripts") : bin_dir(env)

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -34,6 +34,12 @@ module Conda
 using Compat
 import Compat.String
 using JSON
+include("../deps/deps.jl")
+
+if !isdir(default_dir)
+    # Ensure default_dir exists
+    mkpath(default_dir)
+end
 
 type Environment
     path::ASCIIString
@@ -47,11 +53,11 @@ type Environment
         if (length(string(name)) == 0)
             return error("Environment name should be non empty.")
         end
-        return new(abspath(dirname(@__FILE__), "..", "deps", "usr", "envs", string(name)))
+        return new(joinpath(default_dir, "envs", string(name)))
     end
 end
 
-RootEnv = Environment(abspath(dirname(@__FILE__), "..", "deps", "usr"))
+RootEnv = Environment(default_dir)
 
 "Prefix for installation of the environment"
 function prefix(env::Environment)
@@ -143,8 +149,6 @@ function _install_conda(force::Bool=false, env::Environment=RootEnv)
     end
 
     if force || !(is_windows() ? isfile(Conda.conda * ".exe") : isfile(Conda.conda))
-        # Ensure PREFIX exists
-        mkpath(PREFIX)
         info("Downloading miniconda installer ...")
         if is_unix()
             installer = joinpath(PREFIX, "installer.sh")

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -221,9 +221,7 @@ end
 
 "Update all installed packages."
 function update(env::Environment=ROOTENV)
-    for package in _installed_packages()
-        runconda(`update -y $package`, env)
-    end
+    runconda(`update -y --all`, env)
 end
 
 "List all installed packages as an dict of tuples with (version_number, fullname)."

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -100,7 +100,8 @@ end
 const conda = conda_bin(ROOTENV)
 
 "Path to the condarc file"
-const CONDARC = joinpath(PREFIX, "condarc-julia.yml")
+conda_rc(env::Environment) = joinpath(prefix(env), "condarc-julia.yml")
+const CONDARC = conda_rc(ROOTENV)
 
 
 """
@@ -119,7 +120,7 @@ function _set_conda_env(cmd, env::Environment=ROOTENV)
     for var in to_remove
         pop!(env_var, var)
     end
-    env_var["CONDARC"] = joinpath(prefix(env), "condarc-julia.yml")
+    env_var["CONDARC"] = conda_rc(env)
     env_var["CONDA_PREFIX"] = env_var["CONDA_DEFAULT_ENV"] = prefix(env)
     setenv(cmd, env_var)
 end

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -72,24 +72,24 @@ end
 const BINDIR = bin_dir(RootEnv)
 
 "Prefix for the shared libraries installed with the packages"
-function bin_dir(env::Environment)
+function lib_dir(env::Environment)
     return is_windows() ? joinpath(prefix(env), "Library", "bin") : joinpath(prefix(env), "lib")
 end
 const LIBDIR = lib_dir(RootEnv)
 
 "Prefix for the python scripts. On UNIX, this is the same than Conda.BINDIR"
-function scriptdir(env::Environment)
+function script_dir(env::Environment)
     return is_windows() ? joinpath(prefix(env), "Scripts") : bin_dir(env)
 end
-const SCRIPTDIR = scriptdir(RootEnv)
+const SCRIPTDIR = script_dir(RootEnv)
 
 "Prefix where the `python` command lives"
-function pythondir(env::Environment)
+function python_dir(env::Environment)
     return is_windows() ? prefix(env) : bin_dir(env)
 end
-const PYTHONDIR = pythondir(RootEnv)
+const PYTHONDIR = python_dir(RootEnv)
 
-conda_bin(env::Environment) = joinpath(scriptdir(env), "conda")
+conda_bin(env::Environment) = joinpath(script_dir(env), "conda")
 const conda = conda_bin(RootEnv)
 
 "Path to the condarc file"

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -107,7 +107,7 @@ function _set_conda_env(cmd, env::Environment=RootEnv)
         pop!(env_hash, var)
     end
     join_char = is_windows() ? ";" : ":"
-    env_hash["CONDARC"] = CONDARC
+    env_hash["CONDARC"] = joinpath(prefix(env), "condarc-julia")
     env_hash["PATH"] = scriptdir(env) * join_char * env_hash["PATH"]
     env_hash["CONDA_PREFIX"] = prefix(env)
     env_hash["CONDA_DEFAULT_ENV"] = prefix(env)

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -130,13 +130,13 @@ function _set_conda_env(cmd, env::Environment=ROOTENV)
 end
 
 "Run conda command with environment variables set."
-function runconda(args::Cmd, env::Environment=RootEnv)
+function runconda(args::Cmd, env::Environment=ROOTENV)
     _install_conda(env)
     run(_set_conda_env(`$(conda_bin(env)) $args`, env))
 end
 
 "Run conda command with environment variables set and return the output as a string"
-function readconda(args::Cmd, env::Environment=RootEnv)
+function readconda(args::Cmd, env::Environment=ROOTENV)
     _install_conda(env)
     readstring(_set_conda_env(`$(conda_bin(env)) $args`, env))
 end

--- a/src/bindeps_conda.jl
+++ b/src/bindeps_conda.jl
@@ -1,37 +1,37 @@
 # This file contains the necessary ingredients to create a PackageManager for BinDeps
 using BinDeps
 
-type ManagerType{T} <: BinDeps.PackageManager
-    packages::Vector{Compat.ASCIIString}
+type EnvManager{T} <: BinDeps.PackageManager
+    packages::Vector{Compat.UTF8String}
 end
 
 "Manager for root environment"
-Manager = ManagerType{Symbol(PREFIX)}
+typealias Manager EnvManager{Symbol(PREFIX)}
 
-function Base.show{T}(io::IO, manager::ManagerType{T})
+function Base.show{T}(io::IO, manager::EnvManager{T})
     write(io, "Conda packages: ", join(manager.packages, ", "))
 end
 
-BinDeps.can_use{T}(::Type{ManagerType{T}}) = true
+BinDeps.can_use(::Type{EnvManager}) = true
 
-function BinDeps.package_available{T}(manager::ManagerType{T})
+function BinDeps.package_available{T}(manager::EnvManager{T})
     pkgs = manager.packages
     # For each package, see if we can get info about it. If not, fail out
     for pkg in pkgs
-        if !exists(pkg, manager)
+        if !exists(pkg, T)
             return false
         end
     end
     return true
 end
 
-BinDeps.libdir{T}(m::ManagerType{T}, ::Any) = lib_dir(m)
-BinDeps.bindir{T}(m::ManagerType{T}, ::Any) = bin_dir(m)
+BinDeps.libdir{T}(m::EnvManager{T}, ::Any) = lib_dir(T)
+BinDeps.bindir{T}(m::EnvManager{T}, ::Any) = bin_dir(T)
 
-BinDeps.provider{T, S<:String}(::Type{ManagerType{T}}, packages::Vector{S}; opts...) = ManagerType{T}(packages)
-BinDeps.provider{T}(::Type{ManagerType{T}}, packages::String; opts...) = ManagerType{T}([packages])
+BinDeps.provider{T, S<:String}(::Type{EnvManager{T}}, packages::Vector{S}; opts...) = EnvManager{T}(packages)
+BinDeps.provider{T}(::Type{EnvManager{T}}, packages::String; opts...) = EnvManager{T}([packages])
 
-function BinDeps.generate_steps{T}(dep::BinDeps.LibraryDependency, manager::ManagerType{T}, opts)
+function BinDeps.generate_steps(dep::BinDeps.LibraryDependency, manager::EnvManager, opts)
     pkgs = manager.packages
     if isa(pkgs, AbstractString)
         pkgs = [pkgs]
@@ -39,8 +39,8 @@ function BinDeps.generate_steps{T}(dep::BinDeps.LibraryDependency, manager::Mana
     ()->install(pkgs, manager)
 end
 
-function install(pkgs, manager::ManagerType)
+function install{T}(pkgs, manager::EnvManager{T})
     for pkg in pkgs
-        add(pkg, manager)
+        add(pkg, T)
     end
 end

--- a/src/bindeps_conda.jl
+++ b/src/bindeps_conda.jl
@@ -29,18 +29,8 @@ function BinDeps.package_available{T}(manager::ManagerType{T})
     return true
 end
 
-if is_unix()
-    BinDeps.libdir{T}(m::ManagerType{T}, ::Any) = joinpath(prefix(Environment(m)), "lib")
-end
-if is_windows()
-    function BinDeps.libdir{T}(m::ManagerType{T}, ::Any)
-        package = m.packages[1]
-        env = Environment(m)
-        joinpath(prefix(env), "Library", "bin")]
-    end
-end
-
-BinDeps.bindir{T}(m::ManagerType{T}, ::Any) = Conda.bin_dir(Environment(m))
+BinDeps.libdir{T}(m::ManagerType{T}, ::Any) = lib_dir(Environment(m))
+BinDeps.bindir{T}(m::ManagerType{T}, ::Any) = bin_dir(Environment(m))
 
 BinDeps.provider{T, S<:String}(::Type{ManagerType{T}}, packages::Vector{S}; opts...) = ManagerType{T}(packages)
 BinDeps.provider{T}(::Type{ManagerType{T}}, packages::String; opts...) = ManagerType{T}([packages])

--- a/src/bindeps_conda.jl
+++ b/src/bindeps_conda.jl
@@ -36,12 +36,7 @@ if is_windows()
     function BinDeps.libdir{T}(m::ManagerType{T}, ::Any)
         package = m.packages[1]
         env = Environment(m)
-        if package in _installed_packages(env)
-            joinpath(prefix(env), "pkgs", version(package, env), "Library", "bin")
-        else
-            # Return a default path, as we can not call version() on package.
-            joinpath(prefix(env), "lib")
-        end
+        joinpath(prefix(env), "Library", "bin")]
     end
 end
 

--- a/src/bindeps_conda.jl
+++ b/src/bindeps_conda.jl
@@ -5,10 +5,6 @@ type ManagerType{T} <: BinDeps.PackageManager
     packages::Vector{Compat.ASCIIString}
 end
 
-function Environment{T}(manager::ManagerType{T})
-    Environment(T)
-end
-
 "Manager for root environment"
 Manager = ManagerType{Symbol(prefix(RootEnv))}
 
@@ -22,15 +18,15 @@ function BinDeps.package_available{T}(manager::ManagerType{T})
     pkgs = manager.packages
     # For each package, see if we can get info about it. If not, fail out
     for pkg in pkgs
-        if !exists(pkg, Environment(manager))
+        if !exists(pkg, manager)
             return false
         end
     end
     return true
 end
 
-BinDeps.libdir{T}(m::ManagerType{T}, ::Any) = lib_dir(Environment(m))
-BinDeps.bindir{T}(m::ManagerType{T}, ::Any) = bin_dir(Environment(m))
+BinDeps.libdir{T}(m::ManagerType{T}, ::Any) = lib_dir(m)
+BinDeps.bindir{T}(m::ManagerType{T}, ::Any) = bin_dir(m)
 
 BinDeps.provider{T, S<:String}(::Type{ManagerType{T}}, packages::Vector{S}; opts...) = ManagerType{T}(packages)
 BinDeps.provider{T}(::Type{ManagerType{T}}, packages::String; opts...) = ManagerType{T}([packages])
@@ -45,6 +41,6 @@ end
 
 function install(pkgs, manager::ManagerType)
     for pkg in pkgs
-        add(pkg, Environment(manager))
+        add(pkg, manager)
     end
 end

--- a/src/bindeps_conda.jl
+++ b/src/bindeps_conda.jl
@@ -6,7 +6,7 @@ type ManagerType{T} <: BinDeps.PackageManager
 end
 
 "Manager for root environment"
-Manager = ManagerType{Symbol(prefix(rootenv))}
+Manager = ManagerType{Symbol(PREFIX)}
 
 function Base.show{T}(io::IO, manager::ManagerType{T})
     write(io, "Conda packages: ", join(manager.packages, ", "))

--- a/src/bindeps_conda.jl
+++ b/src/bindeps_conda.jl
@@ -6,7 +6,7 @@ type ManagerType{T} <: BinDeps.PackageManager
 end
 
 "Manager for root environment"
-Manager = ManagerType{Symbol(prefix(RootEnv))}
+Manager = ManagerType{Symbol(prefix(rootenv))}
 
 function Base.show{T}(io::IO, manager::ManagerType{T})
     write(io, "Conda packages: ", join(manager.packages, ", "))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,42 +3,38 @@ using BinDeps
 using Base.Test
 using Compat
 
-function main()
-    env = Conda.Environment(:test_conda_jl)
-    @test Conda.exists("curl", env)
-    Conda.add("curl", env)
+env = Conda.Environment(:test_conda_jl)
+@test Conda.exists("curl", env)
+Conda.add("curl", env)
 
-    if is_unix()
-        curl_path = joinpath(Conda.prefix(env), "bin", "curl-config")
-    end
-    if is_windows()
-        curl_path = joinpath(Conda.lib_dir(env), "curl.exe")
-    end
-
-    @test isfile(curl_path)
-
-    @test isfile(joinpath(Conda.bin_dir(env), basename(curl_path)))
-
-    Conda.rm("curl", env)
-    if is_unix()
-        @test !isfile(curl_path)
-    end
-
-    @test isfile(Conda.conda_bin(env))
-    Conda.add("python", env)
-    @test isfile(joinpath(Conda.python_dir(env), "python" * (is_windows() ? ".exe": "")))
-
-    channels = Conda.channels()
-    @test channels == ["defaults"]
-
-    Conda.add_channel("foo", env)
-    @test Conda.channels(env) == ["foo", "defaults"]
-    # Testing that calling the function twice do not fail
-    Conda.add_channel("foo", env)
-
-    Conda.rm_channel("foo", env)
-    channels = Conda.channels(env)
-    @test channels == ["defaults"]
+if is_unix()
+    curl_path = joinpath(Conda.prefix(env), "bin", "curl-config")
+end
+if is_windows()
+    curl_path = joinpath(Conda.lib_dir(env), "curl.exe")
 end
 
-main()
+@test isfile(curl_path)
+
+@test isfile(joinpath(Conda.bin_dir(env), basename(curl_path)))
+
+Conda.rm("curl", env)
+if is_unix()
+    @test !isfile(curl_path)
+end
+
+@test isfile(Conda.conda_bin(env))
+Conda.add("python", env)
+@test isfile(joinpath(Conda.python_dir(env), "python" * (is_windows() ? ".exe": "")))
+
+channels = Conda.channels()
+@test channels == ["defaults"]
+
+Conda.add_channel("foo", env)
+@test Conda.channels(env) == ["foo", "defaults"]
+# Testing that calling the function twice do not fail
+Conda.add_channel("foo", env)
+
+Conda.rm_channel("foo", env)
+channels = Conda.channels(env)
+@test channels == ["defaults"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,8 +12,7 @@ function main()
         curl_path = joinpath(Conda.prefix(env), "bin", "curl-config")
     end
     if is_windows()
-        manager = Conda.libdir(env)
-        curl_path = joinpath(curl_libpath, "curl.exe")
+        curl_path = joinpath(Conda.lib_dir(env), "curl.exe")
     end
 
     @test isfile(curl_path)
@@ -25,7 +24,7 @@ function main()
         @test !isfile(curl_path)
     end
 
-    @test isfile(joinpath(Conda.script_dir(env), "conda" * (is_windows() ? ".exe": "")))
+    @test isfile(Conda.conda_bin(env))
     Conda.add("python", env)
     @test isfile(joinpath(Conda.python_dir(env), "python" * (is_windows() ? ".exe": "")))
 


### PR DESCRIPTION
This PR adds support for conda environments.

With conda environments, you can now install packages in conflict with Python 2.7 (eg. packages linking against msvc2015_runtime are in conflict with Python 2.7 and there was no way to install them before.)

You can also use a systemwide conda environment as well. 
```
conda create -n julia python=3.5
source activate julia
export CONDA_JL_HOME=/home/isuru/miniconda3/envs/julia
julia -e `Pkg.build("Conda")
```