### PR TITLE
rename condarc-julia to condarc-julia.yml

### DIFF
--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -51,7 +51,7 @@ const PYTHONDIR = is_windows() ? PREFIX : BINDIR
 const conda = joinpath(SCRIPTDIR, "conda")
 
 "Path to the condarc file"
-const CONDARC = joinpath(PREFIX, "condarc-julia")
+const CONDARC = joinpath(PREFIX, "condarc-julia.yml")
 
 """
 Use a cleaned up environment for the command `cmd`.

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -164,10 +164,10 @@ end
 function  _installed_packages_dict()
     _install_conda()
     package_dict = Dict{Compat.UTF8String, Tuple{VersionNumber, Compat.UTF8String}}()
-    for line in eachline(`$(Conda.conda) list --export`)
+    for line in eachline(`$(Conda.conda) list`)
         line = chomp(line)
         if !startswith(line, "#")
-            name, version, build_string = split(line, "=")
+            name, version, build_string = split(line)
             # As julia do not accepts xx.yy.zz.rr version number the last part is removed.
             # see issue https://github.com/JuliaLang/julia/issues/7282 a maximum of three levels is inserted
             version_number = join(split(version,".")[1:min(3,end)],".")


### PR DESCRIPTION
avoid a new assertion
```
Traceback (most recent call last):
  File "/Users/travis/.julia/v0.4/Conda/deps/usr/bin/conda", line 4, in <module>
    import conda.cli
  File "/Users/travis/.julia/v0.4/Conda/deps/usr/lib/python2.7/site-packages/conda/cli/__init__.py", line 8, in <module>
    from .main import main  # NOQA
  File "/Users/travis/.julia/v0.4/Conda/deps/usr/lib/python2.7/site-packages/conda/cli/main.py", line 46, in <module>
    from ..base.context import context
  File "/Users/travis/.julia/v0.4/Conda/deps/usr/lib/python2.7/site-packages/conda/base/context.py", line 251, in <module>
    context = Context(SEARCH_PATH, conda, None)
  File "/Users/travis/.julia/v0.4/Conda/deps/usr/lib/python2.7/site-packages/conda/common/configuration.py", line 692, in __init__
    self._add_search_path(search_path)
  File "/Users/travis/.julia/v0.4/Conda/deps/usr/lib/python2.7/site-packages/conda/common/configuration.py", line 699, in _add_search_path
    return self._add_raw_data(load_file_configs(search_path))
  File "/Users/travis/.julia/v0.4/Conda/deps/usr/lib/python2.7/site-packages/conda/common/configuration.py", line 371, in load_file_configs
    raw_data = odict(kv for kv in chain.from_iterable(load_paths))
  File "/Users/travis/.julia/v0.4/Conda/deps/usr/lib/python2.7/collections.py", line 69, in __init__
    self.__update(*args, **kwds)
  File "/Users/travis/.julia/v0.4/Conda/deps/usr/lib/python2.7/_abcoll.py", line 571, in update
    for key, value in other:
  File "/Users/travis/.julia/v0.4/Conda/deps/usr/lib/python2.7/site-packages/conda/common/configuration.py", line 371, in <genexpr>
    raw_data = odict(kv for kv in chain.from_iterable(load_paths))
  File "/Users/travis/.julia/v0.4/Conda/deps/usr/lib/python2.7/site-packages/conda/common/configuration.py", line 346, in _file_yaml_loader
    assert fullpath.endswith(".yml") or fullpath.endswith("condarc"), fullpath
AssertionError: /Users/travis/.julia/v0.4/Conda/deps/usr/condarc-julia
```