### PR TITLE
Allow chosing Python 2 or Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ julia:
     - 0.4
     - 0.5
     - nightly
+env:
+    - MINICONDA_VERSION="2"
+    - MINICONDA_VERSION="3"
+
 notifications:
     email: false
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Parameter `env` is optional and defaults to `ROOTENV`. See below for more info.
 There are two versions of Miniconda, one for Python 2, and one for Python 3.
 This controls the initial version of python uses in the setup of Conda itself,
 and thus the default version of python for all dependancies.
-You can change the version by setting the enviroment variable `MINICONDA_VERSION` to `"3"`,
-before installing any packages.
+You can change the version by setting the enviroment variable `CONDA_JL_VERSION` to `"3"`, prior to installing the Conda.jl package.
+If you change this after Conda.jl has been added, you will need to rerun `Pkg.build("Conda")`.
 Except for the creation of the initial `ROOTENV`, they are identical up to upgrading the version of python, and all that depend upon it.
 See [the Conda documentation for more information](https://conda.io/docs/py2or3.htm).
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ Basic package managing utilities are provided in the Conda module:
 
 Parameter `env` is optional and defaults to `ROOTENV`. See below for more info.
 
+## Miniconda Python Version
+There are two versions of Miniconda, one for Python 2, and one for Python 3.
+This controls the initial version of python uses in the setup of Conda itself,
+and thus the default version of python for all dependancies.
+You can change the version by setting the enviroment variable `MINICONDA_VERSION` to `"3"`,
+before installing any packages.
+Except for the creation of the initial `ROOTENV`, they are identical up to upgrading the version of python, and all that depend upon it.
+See [the Conda documentation for more information](https://conda.io/docs/py2or3.htm).
+
 ### Conda environments
 
 [Conda environments](http://conda.pydata.org/docs/using/envs.html) allow you to

--- a/README.md
+++ b/README.md
@@ -40,15 +40,6 @@ Basic package managing utilities are provided in the Conda module:
 
 Parameter `env` is optional and defaults to `ROOTENV`. See below for more info.
 
-## Miniconda Python Version
-There are two versions of Miniconda, one for Python 2, and one for Python 3.
-This controls the initial version of python uses in the setup of Conda itself,
-and thus the default version of python for all dependancies.
-You can change the version by setting the enviroment variable `CONDA_JL_VERSION` to `"3"`, prior to installing the Conda.jl package.
-If you change this after Conda.jl has been added, you will need to rerun `Pkg.build("Conda")`.
-Except for the creation of the initial `ROOTENV`, they are identical up to upgrading the version of python, and all that depend upon it.
-See [the Conda documentation for more information](https://conda.io/docs/py2or3.htm).
-
 ### Conda environments
 
 [Conda environments](http://conda.pydata.org/docs/using/envs.html) allow you to
@@ -129,6 +120,19 @@ conda create -n conda_jl python
 export CONDA_JL_HOME="/path/to/miniconda/envs/conda_jl"
 julia -e 'Pkg.build("Conda")'
 ```
+## Miniconda Python Version
+There are two versions of Miniconda, one for Python 2, and one for Python 3.
+This controls the initial version of python uses in the setup of Conda itself,
+and thus the default version of python for all dependancies.
+You can change the version by setting the enviroment variable `CONDA_JL_VERSION` to `"3"`, prior to installing the Conda.jl package.
+Except for the creation of the initial `ROOTENV`, they are identical up to upgrading the version of python, and all that depend upon it.
+See [the Conda documentation for more information](https://conda.io/docs/py2or3.htm).
+
+Normal users will not normally need to touch the miniconda verion setting.
+This is provided primary for package developers wishing to test their packages 
+with python dependencies, to ensure it works for both Python 2 and Python 3.
+See docs for defining enviroment variables in [TravisCI](https://docs.travis-ci.com/user/environment-variables/), and [AppVeyor](https://www.appveyor.com/docs/build-configuration/#environment-variables).
+
 
 
 ## Bugs and suggestions

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ provides(Conda.EnvManager{:my_env}, "libnetcdf", netcdf)
 ## Using an already existing Conda installation
 To use an already existing Conda installation, first create an environment for
 `Conda.jl` and then set the `CONDA_JL_HOME` environment variable to the full
-path of the environment. You have to rebuild `Conda.jl` and all the packages
-using `Conda.jl` after this.
+path of the environment. You have to rebuild `Conda.jl` and many of the packages
+that have used it to install their dependancies after this, as their dependancies will need to be added that enviroment.
 
 ```shell
 conda create -n conda_jl python
@@ -125,8 +125,10 @@ There are two versions of Miniconda, one for Python 2, and one for Python 3.
 This controls the initial version of python uses in the setup of Conda itself,
 and thus the default version of python for all dependancies.
 You can change the version by setting the enviroment variable `CONDA_JL_VERSION` to `"3"`, prior to installing the Conda.jl package.
+The Miniconda version used in an existing conda enviroment can not be changed.
 Except for the creation of the initial `ROOTENV`, they are identical up to upgrading the version of python, and all that depend upon it.
 See [the Conda documentation for more information](https://conda.io/docs/py2or3.htm).
+
 
 Normal users will not normally need to touch the miniconda verion setting.
 This is provided primary for package developers wishing to test their packages 

--- a/README.md
+++ b/README.md
@@ -112,8 +112,9 @@ provides(Conda.EnvManager{:my_env}, "libnetcdf", netcdf)
 ## Using an already existing Conda installation
 To use an already existing Conda installation, first create an environment for
 `Conda.jl` and then set the `CONDA_JL_HOME` environment variable to the full
-path of the environment. You have to rebuild `Conda.jl` and many of the packages
-that have used it to install their dependancies after this, as their dependancies will need to be added that enviroment.
+path of the environment.
+You have to rebuild `Conda.jl` and many of the packages that use it after this.
+So as to install their dependancies to the specified enviroment.
 
 ```shell
 conda create -n conda_jl python

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -19,7 +19,7 @@ Setting Miniconda version is not supported for existing Root Enviroments.
 To leave Miniconda version as it is unset the CONDA_JL_VERSION enviroment variable, and rebuild.
 To change Miniconda version, you must delete the Root Enviroment, and rebuild.
 WARNING: deleting the root enviroment will delete all the packages in it.
-This will break any Julia packages that have used Conda to install their dependancies.
+This will break many Julia packages that have used Conda to install their dependancies.
 These will require rebuilding.
 """)
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -12,7 +12,19 @@ end
 ROOTENV = get(ENV, "CONDA_JL_HOME", DefaultDeps.ROOTENV)
 MINICONDA_VERSION = get(ENV, "CONDA_JL_VERSION", DefaultDeps.MINICONDA_VERSION)
 
-deps = """# Generated from $(@__FILE__) on $(now())
+if isdir(ROOTENV) && MINICONDA_VERSION != DefaultDeps.MINICONDA_VERSION
+    error("""Miniconda version changed, since last build.
+However, an Root Enviroment already exists at $(ROOTENV).
+Setting Miniconda version is not supported for existing Root Enviroments.
+To leave Miniconda version as it is unset the CONDA_JL_VERSION enviroment variable, and rebuild.
+To change Miniconda version, you must delete the Root Enviroment, and rebuild.
+WARNING: deleting the root enviroment will delete all the packages in it.
+This will break any Julia packages that have used Conda to install their dependancies.
+These will require rebuilding.
+""")
+end
+
+deps = """
 const ROOTENV="$(escape_string(ROOTENV))"
 const MINICONDA_VERSION="$(escape_string(MINICONDA_VERSION))"
 """

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -14,10 +14,10 @@ MINICONDA_VERSION = get(ENV, "CONDA_JL_VERSION", DefaultDeps.MINICONDA_VERSION)
 
 if isdir(ROOTENV) && MINICONDA_VERSION != DefaultDeps.MINICONDA_VERSION
     error("""Miniconda version changed, since last build.
-However, an Root Enviroment already exists at $(ROOTENV).
-Setting Miniconda version is not supported for existing Root Enviroments.
-To leave Miniconda version as it is unset the CONDA_JL_VERSION enviroment variable, and rebuild.
-To change Miniconda version, you must delete the Root Enviroment, and rebuild.
+However, a root enviroment already exists at $(ROOTENV).
+Setting Miniconda version is not supported for existing root enviroments.
+To leave Miniconda version as, it is unset the CONDA_JL_VERSION enviroment variable and rebuild.
+To change Miniconda version, you must delete the root enviroment and rebuild.
 WARNING: deleting the root enviroment will delete all the packages in it.
 This will break many Julia packages that have used Conda to install their dependancies.
 These will require rebuilding.
@@ -25,8 +25,8 @@ These will require rebuilding.
 end
 
 deps = """
-const ROOTENV="$(escape_string(ROOTENV))"
-const MINICONDA_VERSION="$(escape_string(MINICONDA_VERSION))"
+const ROOTENV = "$(escape_string(ROOTENV))"
+const MINICONDA_VERSION = "$(escape_string(MINICONDA_VERSION))"
 """
 
 if !isfile("deps.jl") || readstring("deps.jl") != deps

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,14 +1,21 @@
 using Compat
 
-if haskey(ENV, "CONDA_JL_HOME")
-    ROOTENV = ENV["CONDA_JL_HOME"]
-elseif isfile("deps.jl")
-    include("deps.jl")
-else
-    ROOTENV = abspath(dirname(@__FILE__), "usr")
+module DefaultDeps
+    if isfile("deps.jl")
+        include("deps.jl")
+    else
+        const ROOTENV = abspath(dirname(@__FILE__), "usr")
+        const MINICONDA_VERSION = "2"
+    end
 end
 
-deps = "const ROOTENV=\"$(escape_string(ROOTENV))\"\n"
+ROOTENV = get(ENV, "CONDA_JL_HOME", DefaultDeps.ROOTENV)
+MINICONDA_VERSION = get(ENV, "CONDA_JL_VERSION", DefaultDeps.MINICONDA_VERSION)
+
+deps = """# Generated from $(@__FILE__) on $(now())
+const ROOTENV="$(escape_string(ROOTENV))"
+const MINICONDA_VERSION="$(escape_string(MINICONDA_VERSION))"
+"""
 
 if !isfile("deps.jl") || readstring("deps.jl") != deps
     write("deps.jl", deps)

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -137,9 +137,11 @@ function parseconda(args::Cmd, env::Environment=ROOTENV)
     JSON.parse(readstring(_set_conda_env(`$(conda_bin(env)) $args --json`, env)))
 end
 
+const MINICONDA_VERSION = get(ENV, "MINICONDA_VERSION", "2")
+
 "Get the miniconda installer URL."
 function _installer_url()
-    res = "https://repo.continuum.io/miniconda/Miniconda2-latest-"
+    res = "https://repo.continuum.io/miniconda/Miniconda$(MINICONDA_VERSION)-latest-"
     if is_apple()
         res *= "MacOSX"
     elseif is_linux()

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -38,7 +38,7 @@ using JSON
 const deps_file = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
 
 if isfile(deps_file)
-    # Includes definition for ROOTENV
+    # Includes definition for ROOTENV, and MINICONDA_VERSION
     include(deps_file)
 else
     error("Conda is not properly configured.  Run Pkg.build(\"Conda\") before importing the Conda module.")
@@ -136,8 +136,6 @@ function parseconda(args::Cmd, env::Environment=ROOTENV)
     _install_conda(env)
     JSON.parse(readstring(_set_conda_env(`$(conda_bin(env)) $args --json`, env)))
 end
-
-const MINICONDA_VERSION = get(ENV, "MINICONDA_VERSION", "2")
 
 "Get the miniconda installer URL."
 function _installer_url()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,10 @@ end
 
 @test isfile(Conda.conda_bin(env))
 Conda.add("python", env)
-@test isfile(joinpath(Conda.python_dir(env), "python" * (is_windows() ? ".exe": "")))
+pythonpath = joinpath(Conda.python_dir(env), "python" * (is_windows() ? ".exe": ""))
+@test isfile(pythonpath)
+pyversion = readstring(`$pythonpath -c "import sys; print(sys.version)"`)
+@test pyversion[1:1] == Conda.MINICONDA_VERSION
 
 channels = Conda.channels()
 @test channels == ["defaults"]


### PR DESCRIPTION
I wished to test one of the packages I contribute to on both Python 3 and Python 2.
https://github.com/malmaud/TensorFlow.jl/issues/251
Because I want to use Conda.jl to install my our dependencies, and the python itself,
I needed Conda to download the right versions of the dependencies.
After looking into it, and some discussion with @Ismael-VC 
concluded the most sensible way to do this was to use an environment variable to change the version of Miniconda being used -- thus changing the default python version.

I added Travis Tests, but not AppVeyor tests,
because A. I know Travis matrixes better,
and B. Having one without the environment variables set means that that can be checked also