### PR TITLE
Suppress progress bar when running in a CI

### DIFF
--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -153,7 +153,7 @@ function _installer_url()
     return res
 end
 
-"Supress progress bar in continuous integration environments"
+"Suppress progress bar in continuous integration environments"
 _quiet() = get(ENV, "CI", "false") == "true" ? `-q` : ``
 
 Compat.Sys.iswindows() && include("outlook.jl")

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -153,6 +153,9 @@ function _installer_url()
     return res
 end
 
+"Supress progress bar in continuous integration environments"
+_quiet() = get(ENV, "CI", "false") == "true" ? `-q` : ``
+
 Compat.Sys.iswindows() && include("outlook.jl")
 
 "Install miniconda if it hasn't been installed yet; _install_conda(true) installs Conda even if it has already been installed."
@@ -196,27 +199,27 @@ function _install_conda(env::Environment, force::Bool=false)
         end
         Conda.add_channel("defaults")
         # Update conda because conda 4.0 is needed and miniconda download installs only 3.9
-        runconda(`update -y conda`)
+        runconda(`update $(_quiet()) -y conda`)
     end
     if !isdir(prefix(env))
         # conda doesn't allow totally empty environments. using zlib as the default package
-        runconda(`create -y -p $(prefix(env)) zlib`)
+        runconda(`create $(_quiet()) -y -p $(prefix(env)) zlib`)
     end
 end
 
 "Install a new package."
 function add(pkg::AbstractString, env::Environment=ROOTENV)
-    runconda(`install -y $pkg`, env)
+    runconda(`install $(_quiet()) -y $pkg`, env)
 end
 
 "Uninstall a package."
 function rm(pkg::AbstractString, env::Environment=ROOTENV)
-    runconda(`remove -y $pkg`, env)
+    runconda(`remove $(_quiet()) -y $pkg`, env)
 end
 
 "Update all installed packages."
 function update(env::Environment=ROOTENV)
-    runconda(`update -y --all`, env)
+    runconda(`update $(_quiet()) -y --all`, env)
 end
 
 "List all installed packages as an dict of tuples with (version_number, fullname)."


### PR DESCRIPTION
When running within the GitLab CI the progress bars provided by conda [produce allot of noise](https://gitlab.com/gitlab-org/gitlab-ci-multi-runner/issues/2154) (not an issue on Travis or Appveyor). Unfortunately there doesn't seem to be a way to currently fix the issue with GitLab CI and the [.condarc file](https://conda.io/docs/config.html) doesn't provide a way of specifying to always be quiet.

This PR allows the quiet flag to be set when the environmental variable "CI" is set to "true". [GitLab CI](https://docs.gitlab.com/ee/ci/variables/), [Travis CI](https://docs.travis-ci.com/user/environment-variables/#Convenience-Variables), and [AppVeyor](https://www.appveyor.com/docs/environment-variables/) automatically set this env variable. The `-q` or `--quiet` flag help simply states "Do not display progress bar". The flag is supported by the following [conda subcommands](https://conda.io/docs/commands.html#conda-general-commands):

* create
* install
* remove
* uninstall
* upgrade
* update