### PR TITLE
Fix deprecation warnings in Julia 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ os:
     - osx
     - linux
 julia:
-    - 0.4
     - 0.5
+    - 0.6
     - nightly
 env:
     - CONDA_JL_VERSION="2"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.5
 BinDeps
 Compat 0.8
 JSON

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,9 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -111,7 +111,7 @@ Any environment variable starting by CONDA or PYTHON will interact with the run.
 """
 function _set_conda_env(cmd, env::Environment=ROOTENV)
     env_var = copy(ENV)
-    to_remove = Compat.UTF8String[]
+    to_remove = String[]
     for var in keys(env_var)
         if startswith(var, "CONDA") || startswith(var, "PYTHON")
             push!(to_remove, var)
@@ -223,7 +223,7 @@ end
 "List all installed packages as an dict of tuples with (version_number, fullname)."
 function  _installed_packages_dict(env::Environment=ROOTENV)
     _install_conda(env)
-    package_dict = Dict{Compat.UTF8String, Tuple{VersionNumber, Compat.UTF8String}}()
+    package_dict = Dict{String, Tuple{VersionNumber, String}}()
     for line in eachline(_set_conda_env(`$(conda_bin(env)) list`, env))
         line = chomp(line)
         if !startswith(line, "#")
@@ -269,7 +269,7 @@ end
 "Search a specific version of a package"
 function search(package::AbstractString, ver::AbstractString, env::Environment=ROOTENV)
     ret=parseconda(`search $package`, env)
-    out = Compat.UTF8String[]
+    out = String[]
     for k in keys(ret)
       for i in 1:length(ret[k])
         ret[k][i]["version"]==ver && push!(out,k)
@@ -297,9 +297,9 @@ end
 function channels(env::Environment=ROOTENV)
     ret=parseconda(`config --get channels`, env)
     if haskey(ret["get"], "channels")
-        return collect(Compat.UTF8String, ret["get"]["channels"])
+        return collect(String, ret["get"]["channels"])
     else
-        return Compat.UTF8String[]
+        return String[]
     end
 end
 

--- a/src/bindeps_conda.jl
+++ b/src/bindeps_conda.jl
@@ -2,7 +2,7 @@
 using BinDeps
 
 type EnvManager{T} <: BinDeps.PackageManager
-    packages::Vector{Compat.UTF8String}
+    packages::Vector{String}
 end
 
 "Manager for root environment"


### PR DESCRIPTION
Drop support for Julia 0.4 (BinDeps only supports 0.5 now)