### PR TITLE
Change from isdefined function to @isdefined macro

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,10 +4,10 @@ module DefaultDeps
     if isfile("deps.jl")
         include("deps.jl")
     end
-    if !isdefined(:ROOTENV)
+    if !@isdefined(ROOTENV)
         const ROOTENV = abspath(dirname(@__FILE__), "usr")
     end
-    if !isdefined(:MINICONDA_VERSION)
+    if !@isdefined(MINICONDA_VERSION)
         const MINICONDA_VERSION = "2"
     end
 end


### PR DESCRIPTION
In Julia v0.7.0 the function form is deprecated and results in what looks like a parse error:

```
julia> Pkg.build("Conda")
INFO: Building Conda
=================================================================[ ERROR: Conda ]==================================================================

LoadError: type CodeInfo has no field def
in expression starting at /Users/patrick/.julia/v0.7/Conda/deps/build.jl:7

===================================================================================================================================================

=================================================================[ BUILD ERRORS ]==================================================================

WARNING: Conda had build errors.

 - packages with build errors remain installed in /Users/patrick/.julia/v0.7
 - build the package(s) and all dependencies with `Pkg.build("Conda")`
 - build a single package by running its `deps/build.jl` script

===================================================================================================================================================
```