### PR TITLE
updates for Julia 0.7, version parsing, and latest conda version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - osx
     - linux
 julia:
-    - 0.5
     - 0.6
     - nightly
 env:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
-julia 0.5
+julia 0.6
 BinDeps
 Compat 0.27.0
 JSON
+VersionParsing

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
 BinDeps
-Compat 0.27.0
+Compat 0.62.0
 JSON
 VersionParsing

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
@@ -27,4 +25,3 @@ build_script:
 
 test_script:
   - C:\projects\julia\bin\julia --check-bounds=yes -e "ENV[\"HOME\"]=joinpath(homedir(),\"Conda test home\"); Pkg.test(\"Conda\")"
-

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -86,21 +86,18 @@ function python_dir(env::Environment)
 end
 const PYTHONDIR = python_dir(ROOTENV)
 
-function conda_bin(env::Environment)
-    if Compat.Sys.iswindows()
-        p = script_dir(env)
-        conda_bat = joinpath(p, "conda.bat")
-        return isfile(conda_bat) ? conda_bat : joinpath(p, "conda.exe")
-    else
-        return joinpath(script_dir(env), "conda")
-    end
+# note: the same conda program is used for all environments
+const conda = if Compat.Sys.iswindows()
+    p = script_dir(ROOTENV)
+    conda_bat = joinpath(p, "conda.bat")
+    isfile(conda_bat) ? conda_bat : joinpath(p, "conda.exe")
+else
+    joinpath(bin_dir(ROOTENV), "conda")
 end
-const conda = conda_bin(ROOTENV)
 
 "Path to the condarc file"
 conda_rc(env::Environment) = joinpath(prefix(env), "condarc-julia.yml")
 const CONDARC = conda_rc(ROOTENV)
-
 
 """
 Use a cleaned up environment for the command `cmd`.
@@ -119,20 +116,20 @@ function _set_conda_env(cmd, env::Environment=ROOTENV)
         pop!(env_var, var)
     end
     env_var["CONDARC"] = conda_rc(env)
-    env_var["CONDA_PREFIX"] = env_var["CONDA_DEFAULT_ENV"] = prefix(env)
+    env_var["CONDA_PREFIX"] = prefix(env)
     setenv(cmd, env_var)
 end
 
 "Run conda command with environment variables set."
 function runconda(args::Cmd, env::Environment=ROOTENV)
     _install_conda(env)
-    run(_set_conda_env(`$(conda_bin(env)) $args`, env))
+    run(_set_conda_env(`$conda $args`, env))
 end
 
 "Run conda command with environment variables set and return the json output as a julia object"
 function parseconda(args::Cmd, env::Environment=ROOTENV)
     _install_conda(env)
-    JSON.parse(readstring(_set_conda_env(`$(conda_bin(env)) $args --json`, env)))
+    JSON.parse(read(_set_conda_env(`$conda $args --json`, env), String))
 end
 
 "Get the miniconda installer URL."
@@ -170,7 +167,7 @@ function _install_conda(env::Environment, force::Bool=false)
                 https://github.com/conda/conda/issues/1084
             """)
         end
-        info("Downloading miniconda installer ...")
+        Compat.@info("Downloading miniconda installer ...")
         if Compat.Sys.isunix()
             installer = joinpath(PREFIX, "installer.sh")
         end
@@ -179,7 +176,7 @@ function _install_conda(env::Environment, force::Bool=false)
         end
         download(_installer_url(), installer)
 
-        info("Installing miniconda ...")
+        Compat.@info("Installing miniconda ...")
         if Compat.Sys.isunix()
             chmod(installer, 33261)  # 33261 corresponds to 755 mode of the 'chmod' program
             run(`$installer -b -f -p $PREFIX`)
@@ -192,8 +189,7 @@ function _install_conda(env::Environment, force::Bool=false)
         runconda(`update $(_quiet()) -y conda`)
     end
     if !isdir(prefix(env))
-        # conda doesn't allow totally empty environments. using zlib as the default package
-        runconda(`create $(_quiet()) -y -p $(prefix(env)) zlib`)
+        runconda(`create $(_quiet()) -y -p $(prefix(env))`)
     end
 end
 
@@ -216,7 +212,7 @@ end
 function  _installed_packages_dict(env::Environment=ROOTENV)
     _install_conda(env)
     package_dict = Dict{String, Tuple{VersionNumber, String}}()
-    for line in eachline(_set_conda_env(`$(conda_bin(env)) list`, env))
+    for line in eachline(_set_conda_env(`$conda list`, env))
         line = chomp(line)
         if !startswith(line, "#")
             name, version, build_string = split(line)
@@ -269,7 +265,7 @@ end
 
 "Check if a given package exists."
 function exists(package::AbstractString, env::Environment=ROOTENV)
-    if contains(package,"==")
+    if occursin("==", package)
       pkg,ver=split(package,"==")  # Remove version if provided
       return pkg in search(pkg,ver,env)
     else

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -31,8 +31,7 @@ provides(Conda.Manager, "libnetcdf", netcdf)
 ```
 """
 module Conda
-using Compat
-using JSON
+using Compat, JSON, VersionParsing
 
 const deps_file = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
 
@@ -221,14 +220,11 @@ function  _installed_packages_dict(env::Environment=ROOTENV)
         line = chomp(line)
         if !startswith(line, "#")
             name, version, build_string = split(line)
-            # As julia do not accepts xx.yy.zz.rr version number the last part is removed.
-            # see issue https://github.com/JuliaLang/julia/issues/7282 a maximum of three levels is inserted
-            version_number = join(split(version,".")[1:min(3,end)],".")
             try
-                package_dict[name] = (convert(VersionNumber, version_number), line)
+                package_dict[name] = (vparse(version), line)
             catch
                 package_dict[name] = (v"9999.9999.9999", line)
-                warn("Failed parsing string: \"$(version_number)\" to a version number. Please open an issue!")
+                warn("Failed parsing string: \"$(version)\" to a version number. Please open an issue!")
             end
         end
     end

--- a/src/bindeps_conda.jl
+++ b/src/bindeps_conda.jl
@@ -1,20 +1,20 @@
 # This file contains the necessary ingredients to create a PackageManager for BinDeps
 using BinDeps
 
-type EnvManager{T} <: BinDeps.PackageManager
+struct EnvManager{T} <: BinDeps.PackageManager
     packages::Vector{String}
 end
 
 "Manager for root environment"
 const Manager = EnvManager{Symbol(PREFIX)}
 
-function Base.show{T}(io::IO, manager::EnvManager{T})
+function Base.show(io::IO, manager::EnvManager)
     write(io, "Conda packages: ", join(manager.packages, ", "))
 end
 
 BinDeps.can_use(::Type{EnvManager}) = true
 
-function BinDeps.package_available{T}(manager::EnvManager{T})
+function BinDeps.package_available(manager::EnvManager{T}) where {T}
     pkgs = manager.packages
     # For each package, see if we can get info about it. If not, fail out
     for pkg in pkgs
@@ -25,21 +25,18 @@ function BinDeps.package_available{T}(manager::EnvManager{T})
     return true
 end
 
-BinDeps.libdir{T}(m::EnvManager{T}, ::Any) = lib_dir(T)
-BinDeps.bindir{T}(m::EnvManager{T}, ::Any) = bin_dir(T)
+BinDeps.libdir(m::EnvManager{T}, ::Any) where {T} = lib_dir(T)
+BinDeps.bindir(m::EnvManager{T}, ::Any) where {T} = bin_dir(T)
 
-BinDeps.provider{T, S<:String}(::Type{EnvManager{T}}, packages::Vector{S}; opts...) = EnvManager{T}(packages)
-BinDeps.provider{T}(::Type{EnvManager{T}}, packages::String; opts...) = EnvManager{T}([packages])
+BinDeps.provider(::Type{EnvManager{T}}, packages::AbstractVector{<:AbstractString}; opts...) where {T} = EnvManager{T}(packages)
+BinDeps.provider(::Type{EnvManager{T}}, packages::AbstractString; opts...) where {T} = EnvManager{T}([packages])
 
 function BinDeps.generate_steps(dep::BinDeps.LibraryDependency, manager::EnvManager, opts)
     pkgs = manager.packages
-    if isa(pkgs, AbstractString)
-        pkgs = [pkgs]
-    end
     ()->install(pkgs, manager)
 end
 
-function install{T}(pkgs, manager::EnvManager{T})
+function install(pkgs, manager::EnvManager{T}) where {T}
     for pkg in pkgs
         add(pkg, T)
     end


### PR DESCRIPTION
This PR includes several updates:

* Fix 0.7 deprecations.

* Fix test failures on latest conda version — previously, each environment got its own `conda` executable, but nowadays it seems that they all use the `conda` in the root environment.  Various other portions of the tests seem to have bitrotted as well.

* Use the VersionParsing package to parse non-semver package version numbers into `VersionNumber`.

* Drops 0.5 support.