### PR TITLE
Fix README: CONDA_JL_HOME requires bin/conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ You have to rebuild `Conda.jl` and many of the packages that use it after this.
 So as to install their dependancies to the specified enviroment.
 
 ```shell
-conda create -n conda_jl python
+conda create -n conda_jl python conda
 export CONDA_JL_HOME="/path/to/miniconda/envs/conda_jl"
 julia -e 'Pkg.build("Conda")'
 ```


### PR DESCRIPTION
I think old instruction README was incorrect since `_install_conda` tries to install miniconda to `$CONDA_JL_HOME` unless `$CONDA_JL_HOME/bin/conda` exists:

https://github.com/JuliaPy/Conda.jl/blob/bc6a78ecda2741684611bf5344b155005f9acaa7/src/Conda.jl#L157-L159

I'm using:

```
$ conda --version
conda 4.5.4
```