### PR TITLE
Change isdefined for @isdefined because the new function isdefined needs

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,10 +4,10 @@ module DefaultDeps
     if isfile("deps.jl")
         include("deps.jl")
     end
-    if !isdefined(:ROOTENV)
+    if !@isdefined(ROOTENV)
         const ROOTENV = abspath(dirname(@__FILE__), "usr")
     end
-    if !isdefined(:MINICONDA_VERSION)
+    if !@isdefined(MINICONDA_VERSION)
         const MINICONDA_VERSION = "3"
     end
 end
@@ -32,7 +32,7 @@ const ROOTENV = "$(escape_string(ROOTENV))"
 const MINICONDA_VERSION = "$(escape_string(MINICONDA_VERSION))"
 """
 
-if !isfile("deps.jl") || readstring("deps.jl") != deps
+if !isfile("deps.jl") || open(f->read(f,String),"deps.jl") != deps
     write("deps.jl", deps)
 end
 


### PR DESCRIPTION
I'm not sure if my PR is sufficent, but I managed to install Conda with the new version 1.0.
i need to modify 
isdefined for the macro @isdefined  because the new version has two arguments
I replace also readstring by open(f->read(f,String)