### PR TITLE
install into global ~/.julia/conda directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os:
     - osx
     - linux
 julia:
-    - 0.6
+    - 0.7
+    - 1.0
     - nightly
 env:
     - CONDA_JL_VERSION="2"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.7
 Compat 0.62.0
 JSON
 VersionParsing

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-  - julia_version: 0.6
   - julia_version: 0.7
   - julia_version: 1
   - julia_version: nightly

--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -1,3 +1,2 @@
-usr/
 deps.jl
 !.gitignore

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -10,11 +10,11 @@ module DefaultDeps
     elseif isfile(Main.condadeps)
         include(Main.condadeps)
     end
-    if !isdefined(@__MODULE__, :ROOTENV)
-        const ROOTENV = Main.condadir
-    end
     if !isdefined(@__MODULE__, :MINICONDA_VERSION)
         const MINICONDA_VERSION = "3"
+    end
+    if !isdefined(@__MODULE__, :ROOTENV)
+        const ROOTENV = joinpath(Main.condadir, MINICONDA_VERSION)
     end
 end
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,12 +1,17 @@
 using Compat
 
+const condadir = abspath(homedir(), ".julia", "conda")
+const condadeps = joinpath(condadir, "deps.jl")
+
 module DefaultDeps
     using Compat
     if isfile("deps.jl")
         include("deps.jl")
+    elseif isfile(Main.condadeps)
+        include(Main.condadeps)
     end
     if !isdefined(@__MODULE__, :ROOTENV)
-        const ROOTENV = abspath(dirname(@__FILE__), "usr")
+        const ROOTENV = Main.condadir
     end
     if !isdefined(@__MODULE__, :MINICONDA_VERSION)
         const MINICONDA_VERSION = "3"
@@ -33,11 +38,11 @@ const ROOTENV = "$(escape_string(ROOTENV))"
 const MINICONDA_VERSION = "$(escape_string(MINICONDA_VERSION))"
 """
 
-if !isfile("deps.jl") || read("deps.jl", String) != deps
-    write("deps.jl", deps)
-end
+mkpath(condadir)
+mkpath(ROOTENV)
 
-if !isdir(ROOTENV)
-    # Ensure ROOTENV exists, otherwise prefix(ROOTENV) will throw
-    mkpath(ROOTENV)
+for depsfile in ("deps.jl", condadeps)
+    if !isfile(depsfile) || read(depsfile, String) != deps
+        write(depsfile, deps)
+    end
 end


### PR DESCRIPTION
Fixes #123.

In the future, we should allow Pkg projects to use a separate Conda virtualenv and set of packages, but that seems like it will have to wait for persistent package options support (JuliaLang/Juleps#38 or similar).

Drops Julia 0.6 since in Julia 0.6 there is already a single global directory (`~/.julia/v0.6/Conda/deps/usr`) and I don't think we want to move it.