### PR TITLE
Recreating environments

### DIFF
--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -231,8 +231,12 @@ NOTE: Because export is a reserved word we use the term freeze from python
 function freeze(filepath::AbstractString, env::Environment=ROOTENV)
     _install_conda(env)
     open(filepath, "w") do fobj
-        write(fobj, read(_set_conda_env(`$conda list --export`, env)))
+        freeze(fobj, env)
     end
+end
+
+function freeze(io::IO, env::Environment=ROOTENV)
+    write(io, read(_set_conda_env(`$conda list --export`, env)))
 end
 
 "Get the exact version of a package as a `VersionNumber`."
@@ -340,6 +344,14 @@ function create(
         `$conda create $(_quiet()) -y -p $(prefix(env)) $channel_str --file $filepath`,
         env
     ))
+end
+
+function create(io::IO, args...; kwargs...)
+    mktemp() do path, fobj
+        write(fobj, read(io))
+        close(fobj)
+        create(path, args...; kwargs...)
+    end
 end
 
 end

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -225,6 +225,9 @@ function list(env::Environment=ROOTENV)
 end
 
 """
+    export_list(filepath, env=$ROOTENV)
+    export_list(io, env=$ROOTENV)
+
 List all packages and write them to an export file for use the Conda.create
 NOTE: Because export is a reserved word we use the term freeze from python
 """
@@ -333,7 +336,12 @@ function clean(;
     run(_set_conda_env(cmd))
 end
 
-"Create a new environment with various channels and a packages file."
+""""
+    create(filename, env=$ROOTENV, channels=String[])
+    create(io, env=$ROOTENV, channels=String[])
+
+Create a new environment with various channels and a packages file.
+"""
 function create(
     filepath::AbstractString,
     env::Environment=ROOTENV;

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -228,14 +228,14 @@ end
 List all packages and write them to an export file for use the Conda.create
 NOTE: Because export is a reserved word we use the term freeze from python
 """
-function freeze(filepath::AbstractString, env::Environment=ROOTENV)
+function export_list(filepath::AbstractString, env::Environment=ROOTENV)
     _install_conda(env)
     open(filepath, "w") do fobj
-        freeze(fobj, env)
+        export_list(fobj, env)
     end
 end
 
-function freeze(io::IO, env::Environment=ROOTENV)
+function export_list(io::IO, env::Environment=ROOTENV)
     write(io, read(_set_conda_env(`$conda list --export`, env)))
 end
 

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -228,8 +228,7 @@ end
     export_list(filepath, env=$ROOTENV)
     export_list(io, env=$ROOTENV)
 
-List all packages and write them to an export file for use the Conda.create
-NOTE: Because export is a reserved word we use the term freeze from python
+List all packages and write them to an export file for use the Conda.import_list
 """
 function export_list(filepath::AbstractString, env::Environment=ROOTENV)
     _install_conda(env)
@@ -337,12 +336,12 @@ function clean(;
 end
 
 """"
-    create(filename, env=$ROOTENV, channels=String[])
-    create(io, env=$ROOTENV, channels=String[])
+    import_list(filename, env=$ROOTENV, channels=String[])
+    import_list(io, env=$ROOTENV, channels=String[])
 
-Create a new environment with various channels and a packages file.
+Create a new environment with various channels and a packages list file.
 """
-function create(
+function import_list(
     filepath::AbstractString,
     env::Environment=ROOTENV;
     channels=String[]
@@ -354,11 +353,11 @@ function create(
     ))
 end
 
-function create(io::IO, args...; kwargs...)
+function import_list(io::IO, args...; kwargs...)
     mktemp() do path, fobj
         write(fobj, read(io))
         close(fobj)
-        create(path, args...; kwargs...)
+        import_list(path, args...; kwargs...)
     end
 end
 

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -224,6 +224,17 @@ function list(env::Environment=ROOTENV)
     runconda(`list`, env)
 end
 
+"""
+List all packages and write them to an export file for use the Conda.create
+NOTE: Because export is a reserved word we use the term freeze from python
+"""
+function freeze(filepath::AbstractString, env::Environment=ROOTENV)
+    _install_conda(env)
+    open(filepath, "w") do fobj
+        write(fobj, read(_set_conda_env(`$conda list --export`, env)))
+    end
+end
+
 "Get the exact version of a package as a `VersionNumber`."
 function version(name::AbstractString, env::Environment=ROOTENV)
     packages = parseconda(`list`, env)
@@ -316,6 +327,19 @@ function clean(;
     ]
     cmd = Cmd([conda, "clean", "--yes", flags[kwargs]...])
     run(_set_conda_env(cmd))
+end
+
+"Create a new environment with various channels and a packages file."
+function create(
+    filepath::AbstractString,
+    env::Environment=ROOTENV;
+    channels=String[]
+)
+    channel_str = ["-c $channel" for channel in channels]
+    run(_set_conda_env(
+        `$conda create $(_quiet()) -y -p $(prefix(env)) $channel_str --file $filepath`,
+        env
+    ))
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,3 +63,19 @@ end
 
 # Run conda clean
 Conda.clean(; debug=true)
+
+@testset "Exporting and creating environments" begin
+    new_env = :test_conda_jl_2
+    Conda.add("curl", env)
+    Conda.freeze("conda-pkg.txt", env)
+
+    # Create a new environment
+    rm(Conda.prefix(new_env); force=true, recursive=true)
+    Conda.create("conda-pkg.txt", new_env; channels=["defaults", "conda-forge"])
+
+    # Ensure that our new environment has our channels and package installed.
+    Conda.channels(new_env) == ["defaults", "conda-forge"]
+    installed = Conda._installed_packages(new_env)
+    @test "curl" ∈ installed
+    rm("conda-pkg.txt")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,7 +71,7 @@ Conda.clean(; debug=true)
 
     # Create a new environment
     rm(Conda.prefix(new_env); force=true, recursive=true)
-    Conda.create(
+    Conda.import_list(
         IOBuffer(read("conda-pkg.txt")), new_env; channels=["defaults", "conda-forge"]
     )
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,7 +67,7 @@ Conda.clean(; debug=true)
 @testset "Exporting and creating environments" begin
     new_env = :test_conda_jl_2
     Conda.add("curl", env)
-    Conda.freeze("conda-pkg.txt", env)
+    Conda.export_list("conda-pkg.txt", env)
 
     # Create a new environment
     rm(Conda.prefix(new_env); force=true, recursive=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,7 +71,9 @@ Conda.clean(; debug=true)
 
     # Create a new environment
     rm(Conda.prefix(new_env); force=true, recursive=true)
-    Conda.create("conda-pkg.txt", new_env; channels=["defaults", "conda-forge"])
+    Conda.create(
+        IOBuffer(read("conda-pkg.txt")), new_env; channels=["defaults", "conda-forge"]
+    )
 
     # Ensure that our new environment has our channels and package installed.
     Conda.channels(new_env) == ["defaults", "conda-forge"]


### PR DESCRIPTION
Added Conda.freeze and Conda.create functions for re-creating environments.

NOTE: I would have done `Conda.export` if `export` wasn't already a keyword, but `freeze` (e.g., `pip freeze`) seemed like the next best thing. 