### PR TITLE
Specify channel when adding package

### DIFF
--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -179,8 +179,9 @@ end
 const PkgOrPkgs = Union{AbstractString, AbstractVector{<: AbstractString}}
 
 "Install a new package or packages."
-function add(pkg::PkgOrPkgs, env::Environment=ROOTENV)
-    runconda(`install $(_quiet()) -y $pkg`, env)
+function add(pkg::PkgOrPkgs, env::Environment=ROOTENV; channel::AbstractString="")
+    c = isempty(channel) ? `` : `-c $channel`
+    runconda(`install $(_quiet()) -y $c $pkg`, env)
 end
 
 "Uninstall a package or packages."

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,6 +49,9 @@ Conda.add_channel("foo", env)
 Conda.rm_channel("foo", env)
 @test Conda.channels(env) == ["defaults"]
 
+# Add a package from a specific channel
+Conda.add("requests", env; channel="conda-forge")
+
 @testset "Batch install and uninstall" begin
     Conda.add(["affine", "ansi2html"], env)
     installed = Conda._installed_packages(env)


### PR DESCRIPTION
First step in changing the behaviour of `pyimport_conda` to guarantee the installation of a package from a specified channel(e.g., `conda install -y -c conda-forge requests`).