### PR TITLE
Pass --file to `conda config` to avoid writing to `~/.condarc`

### DIFF
--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -288,7 +288,7 @@ end
 
 "Get the list of channels used to search packages"
 function channels(env::Environment=ROOTENV)
-    ret=parseconda(`config --get channels`, env)
+    ret=parseconda(`config --get channels --file $(conda_rc(env))`, env)
     if haskey(ret["get"], "channels")
         return collect(String, ret["get"]["channels"])
     else
@@ -298,12 +298,12 @@ end
 
 "Add a channel to the list of channels"
 function add_channel(channel::AbstractString, env::Environment=ROOTENV)
-    runconda(`config --add channels $channel --force`, env)
+    runconda(`config --add channels $channel --file $(conda_rc(env)) --force`, env)
 end
 
 "Remove a channel from the list of channels"
 function rm_channel(channel::AbstractString, env::Environment=ROOTENV)
-    runconda(`config --remove channels $channel --force`, env)
+    runconda(`config --remove channels $channel --file $(conda_rc(env)) --force`, env)
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,6 +46,11 @@ Conda.add_channel("foo", env)
 # Testing that calling the function twice do not fail
 Conda.add_channel("foo", env)
 
+@test occursin("foo", read(Conda.conda_rc(env), String))
+homerc = joinpath(homedir(), ".condarc")
+
+@test !isfile(homerc) || !occursin("foo", read(homerc, String))
+
 Conda.rm_channel("foo", env)
 @test Conda.channels(env) == ["defaults"]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,17 +41,22 @@ pythonpath = joinpath(Conda.PYTHONDIR, "python" * exe)
 pyversion = read(`$pythonpath -c "import sys; print(sys.version)"`, String)
 @test pyversion[1:1] == Conda.MINICONDA_VERSION
 
+condarc_path = joinpath(homedir(), ".condarc")
+last_modified = mtime(condarc_path)
+
 Conda.add_channel("foo", env)
 @test Conda.channels(env) == ["foo", "defaults"]
+
 # Testing that calling the function twice do not fail
 Conda.add_channel("foo", env)
 
+# Validate that only the Conda.jl RC file was modified
 @test occursin("foo", read(Conda.conda_rc(env), String))
-homerc = joinpath(homedir(), ".condarc")
-
-@test !isfile(homerc) || !occursin("foo", read(homerc, String))
+@test !isfile(condarc_path) || !occursin("foo", read(condarc_path, String))
 
 Conda.rm_channel("foo", env)
+@test mtime(condarc_path) == last_modified
+
 @test Conda.channels(env) == ["defaults"]
 
 @testset "Batch install and uninstall" begin


### PR DESCRIPTION
Appears to fix #140 