### PR TITLE
Update Conda.jl

### DIFF
--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -77,7 +77,11 @@ const conda = if Compat.Sys.iswindows()
     conda_bat = joinpath(p, "conda.bat")
     isfile(conda_bat) ? conda_bat : joinpath(p, "conda.exe")
 else
-    joinpath(bin_dir(ROOTENV), "conda")
+    if haskey(ENV, "CONDA_EXE")
+        ENV["CONDA_EXE"]
+    else
+        joinpath(bin_dir(ROOTENV), "conda")
+    end
 end
 
 "Path to the condarc file"


### PR DESCRIPTION
For changes since [Conda@4.4.0#recommended-change-to-enable-conda-in-your-shell](https://github.com/conda/conda/blob/c06cee03757b2946831d8d5006ecffce9eb6d053/docs/source/release-notes.rst#recommended-change-to-enable-conda-in-your-shell), when non-root Conda Environment is used, executable file `conda` will not necessarily exists under `bin_dir(ROOTENV)`, which causing Conda.jl constantly try to install Miniconda. 

Using environment variable `$CONDA_EXE` to locate `conda` executable is recommend.

For example:

```bash
# creating non-root conda env
conda create -n conda_jl python conda
# add following line to `~/.bashrc`, `~/.zshrc` or other rc files to avoid typing everytime
export CONDA_JL_HOME="/path/to/miniconda/envs/conda_jl"
# rebuild Conda
julia -e 'using Pkg; Pkg.build("Conda")'
#  try to list installed Conda packages
julia -e 'using Conda; Conda.list()'  # will still trying to install miniconda
```

Test passed with `test Conda`.