### PR TITLE
Add support for Power9 and error on unsupported Sys.ARCH

### DIFF
--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -145,7 +145,7 @@ function _installer_url()
     elseif Sys.ARCH == :ppc64le
         res *= "-ppc64le"
     else
-        error("Unsupported architecture: $Sys.ARCH")
+        error("Unsupported architecture: $(Sys.ARCH)")
     end
 
     res *= Sys.iswindows() ? ".exe" : ".sh"

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -140,10 +140,8 @@ function _installer_url()
         error("Unsuported OS.")
     end
 
-    if Sys.ARCH == :x86 || Sys.ARCH == :x86_64
-        res *= Sys.WORD_SIZE == 64 ? "-x86_64" : "-x86"
-    elseif Sys.ARCH == :ppc64le
-        res *= "-ppc64le"
+    if Sys.ARCH in (:x86, :x86_64, :ppc64le)
+        res *= string('-',Sys.ARCH)
     else
         error("Unsupported architecture: $(Sys.ARCH)")
     end

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -140,8 +140,11 @@ function _installer_url()
         error("Unsuported OS.")
     end
 
-    if Sys.ARCH in (:x86, :x86_64, :ppc64le)
-        res *= string('-',Sys.ARCH)
+    # mapping of Julia architecture names to Conda architecture names, where they differ
+    arch2conda = Dict(:i686 => :x86)
+    
+    if Sys.ARCH in (:i686, :x86_64, :ppc64le)
+        res *= string('-', get(arch2conda, Sys.ARCH, Sys.ARCH))
     else
         error("Unsupported architecture: $(Sys.ARCH)")
     end

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -139,7 +139,15 @@ function _installer_url()
     else
         error("Unsuported OS.")
     end
-    res *= Sys.WORD_SIZE == 64 ? "-x86_64" : "-x86"
+
+    if Sys.ARCH == :x86 || Sys.ARCH == :x86_64
+        res *= Sys.WORD_SIZE == 64 ? "-x86_64" : "-x86"
+    elseif Sys.ARCH == :ppc64le
+        res *= "-ppc64le"
+    else
+        error("Unsupported architecture: $Sys.ARCH")
+    end
+
     res *= Sys.iswindows() ? ".exe" : ".sh"
     return res
 end


### PR DESCRIPTION
I'm starting to use Julia on Power9 (I believe still officially unsupported) and noticed that Conda.jl downloads and tries to install x86 miniconda on Power9 which fails (see link to sample stacktrace below).

Turns out miniconda provides Power9 builds so this PR adds support for Conda.jl on Power9. Conda.jl should now error when trying to install miniconda on an unsupported architecture.

Could have probably done `res *= string(Sys.ARCH)` but that probably won't work for all `Sys.ARCH`.

Unfortunately I'm not aware of any way of testing this on Travis CI or Appveyor but I ran the Conda.jl tests on a Power9 system and they all passed (see link to log below).

Conda.jl fails on Power9 stacktrace: https://gist.github.com/ali-ramadhan/6a36885905a3f245e7dedb418a867116
Conda.jl test log on Power9: https://gist.github.com/ali-ramadhan/cda0a74931f874040a88fb0cef638754