### PR TITLE
add bin_dir to PATH on windows to fix DLL paths

### DIFF
--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -313,13 +313,13 @@ end
 
 """
     clean(;
-        debug=false, index=true, locks=true, tarballs=true, packages=true, sources=true
+        debug=false, index=true, locks=false, tarballs=true, packages=true, sources=true
     )
 
 Runs `conda clean -y` with the specified flags.
 """
 function clean(;
-    debug=false, index=true, locks=true, tarballs=true, packages=true, sources=true
+    debug=false, index=true, locks=false, tarballs=true, packages=true, sources=true
 )
     kwargs = [debug, index, locks, tarballs, packages, sources]
     if !any(kwargs[2:end])
@@ -327,10 +327,14 @@ function clean(;
             "Please specify 1 or more of the conda artifacts to clean up (e.g., `packages=true`)."
         )
     end
+    if locks
+        @warn "clean --lock is no longer supported in Anaconda 4.8.0"
+    end
 
     flags = [
         "--debug",
         "--index-cache",
+        "--lock",
         "--tarballs",
         "--packages",
         "--source-cache",

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -103,6 +103,9 @@ function _set_conda_env(cmd, env::Environment=ROOTENV)
     env_var["PYTHONIOENCODING"]="UTF-8"
     env_var["CONDARC"] = conda_rc(env)
     env_var["CONDA_PREFIX"] = prefix(env)
+    if Sys.iswindows()
+        env_var["PATH"] = bin_dir(env) * ';' * get(env_var, "PATH", ""))
+    end
     setenv(cmd, env_var)
 end
 

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -331,7 +331,6 @@ function clean(;
     flags = [
         "--debug",
         "--index-cache",
-        "--lock",
         "--tarballs",
         "--packages",
         "--source-cache",

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -104,7 +104,7 @@ function _set_conda_env(cmd, env::Environment=ROOTENV)
     env_var["CONDARC"] = conda_rc(env)
     env_var["CONDA_PREFIX"] = prefix(env)
     if Sys.iswindows()
-        env_var["PATH"] = bin_dir(env) * ';' * get(env_var, "PATH", ""))
+        env_var["PATH"] = bin_dir(env) * ';' * get(env_var, "PATH", "")
     end
     setenv(cmd, env_var)
 end


### PR DESCRIPTION
Attempt to fix AppVeyor failure as describe here: https://github.com/JuliaPy/Conda.jl/pull/162#issuecomment-567961168

(Windows uses the `PATH` environment variable to [find DLLs](https://msdn.microsoft.com/en-us/ie/aa297182(v=vs.100)), and apparently `conda` expects this to be set in order to run properly — it happens when you "activate" the Conda environment in normal usage.)

Also fix a test failure due to the `--lock` argument being dropped from the latest conda release (conda/conda#8310).