### PR TITLE
Fixing exists by adding keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ where you can type `add Conda` to install this package.
 
 Once Conda is installed, you can run `import Conda` to load the package and run a variety of package-management functions:
 
-- `Conda.add(package, env; channel="")`: install a package from a specified channel (optional);
-- `Conda.rm(package, env)`: remove (uninstall) a package;
-- `Conda.update(env)`: update all installed packages to the latest version;
-- `Conda.list(env)`: list all installed packages.
-- `Conda.add_channel(channel, env)`: add a channel to the list of channels;
-- `Conda.channels(env)`: get the current list of channels;
-- `Conda.rm_channel(channel, env)`: remove a channel from the list of channels;
+- `Conda.add(package; env=ROOTENV, channel="")` or `Conda.add(package, env=ROOTENV; channel="")`: install a package from a specified channel (optional);
+- `Conda.rm(package, env=ROOTENV)`: remove (uninstall) a package;
+- `Conda.update(env=ROOTENV)`: update all installed packages to the latest version;
+- `Conda.list(env=ROOTENV)`: list all installed packages.
+- `Conda.add_channel(channel, env=ROOTENV)`: add a channel to the list of channels;
+- `Conda.channels(env=ROOTENV)`: get the current list of channels;
+- `Conda.rm_channel(channel, env=ROOTENV)`: remove a channel from the list of channels;
 
 The parameter `env` is optional and defaults to `ROOTENV`. See below for more info.
 

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -291,7 +291,7 @@ function exists(package::AbstractString, env::Environment=ROOTENV)
       pkg,ver=split(package,"==")  # Remove version if provided
       return pkg in search(pkg,ver,env)
     else
-      if package in search(package,env)
+      if package in search(package,Symbol(env))
         # Found exactly this package
         return true
       else

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -192,7 +192,11 @@ end
 const PkgOrPkgs = Union{AbstractString, AbstractVector{<: AbstractString}}
 
 "Install a new package or packages."
-function add(pkg::PkgOrPkgs, env::Environment=ROOTENV; channel::AbstractString="")
+function add(pkg::PkgOrPkgs; env::Environment=ROOTENV, channel::AbstractString="")
+    add(pkg,env,channel)
+end
+
+function add(pkg::PkgOrPkgs, env::Environment, channel::AbstractString="")
     c = isempty(channel) ? `` : `-c $channel`
     runconda(`install $(_quiet()) -y $c $pkg`, env)
 end
@@ -266,12 +270,12 @@ function version(name::AbstractString, env::Environment=ROOTENV)
 end
 
 "Search packages for a string"
-function search(package::AbstractString, env::Environment=ROOTENV)
+function search(package::AbstractString; env::Environment=ROOTENV)
     return collect(keys(parseconda(`search $package`, env)))
 end
 
 "Search a specific version of a package"
-function search(package::AbstractString, _ver::Union{AbstractString,VersionNumber}, env::Environment=ROOTENV)
+function search(package::AbstractString, _ver::Union{AbstractString,VersionNumber}; env::Environment=ROOTENV)
     ret=parseconda(`search $package`, env)
     out = String[]
     ver = string(_ver)
@@ -286,12 +290,12 @@ function search(package::AbstractString, _ver::Union{AbstractString,VersionNumbe
 end
 
 "Check if a given package exists."
-function exists(package::AbstractString, env::Environment=ROOTENV)
+function exists(package::AbstractString; env::Environment=ROOTENV)
     if occursin("==", package)
       pkg,ver=split(package,"==")  # Remove version if provided
-      return pkg in search(pkg,ver,env)
+      return pkg in search(pkg,ver,env=env)
     else
-      if package in search(package,Symbol(env))
+      if package in search(package,env=Symbol(env))
         # Found exactly this package
         return true
       else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ env = :test_conda_jl
 rm(Conda.prefix(env); force=true, recursive=true)
 
 @test Conda.exists("curl", env)
+@test Conda.exists("curl", "test_conda_jl")
 Conda.add("curl", env)
 
 @testset "Install Python package" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,12 +7,12 @@ Conda.update()
 env = :test_conda_jl
 rm(Conda.prefix(env); force=true, recursive=true)
 
-@test Conda.exists("curl", env)
-@test Conda.exists("curl", "test_conda_jl")
+@test Conda.exists("curl", env=env)
+@test Conda.exists("curl", env="test_conda_jl")
 Conda.add("curl", env)
 
 @testset "Install Python package" begin
-    Conda.add("python=3.6", env)  # 3.7 doesn't work on Windows at the moment
+    Conda.add("python=3.6", env=env)  # 3.7 doesn't work on Windows at the moment
     pythonpath = joinpath(Conda.python_dir(env), "python" * exe)
     @test isfile(pythonpath)
 
@@ -24,12 +24,12 @@ end
 
 curlvers = Conda.version("curl",env)
 @test curlvers >= v"5.0"
-@test Conda.exists("curl==$curlvers", env)
+@test Conda.exists("curl==$curlvers", env=env)
 
 curl_path = joinpath(Conda.bin_dir(env), "curl" * exe)
 @test isfile(curl_path)
 
-@test "curl" in Conda.search("cu*", env)
+@test "curl" in Conda.search("cu*", env=env)
 
 Conda.rm("curl", env)
 @test !isfile(curl_path)
@@ -58,10 +58,10 @@ Conda.rm_channel("foo", env)
 @test Conda.channels(env) == ["defaults"]
 
 # Add a package from a specific channel
-Conda.add("requests", env; channel="conda-forge")
+Conda.add("requests"; env=env, channel="conda-forge")
 
 @testset "Batch install and uninstall" begin
-    Conda.add(["affine", "ansi2html"], env)
+    Conda.add(["affine", "ansi2html"], env=env)
     installed = Conda._installed_packages(env)
     @test "affine" ∈ installed
     @test "ansi2html" ∈ installed


### PR DESCRIPTION
Exists doesn't work when you have an environment that's a string, such as if you have a different root environment. The first commit just addresses exists, while the second one adds keyword values inspired by https://github.com/JuliaPy/Conda.jl/issues/118.