### PR TITLE
unpin Anaconda on Windows

### DIFF
--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -129,13 +129,6 @@ function _installer_url()
     elseif Sys.islinux()
         res *= "Linux"
     elseif Sys.iswindows()
-        if MINICONDA_VERSION == "3"
-            # Quick fix for:
-            # * https://github.com/JuliaLang/IJulia.jl/issues/739
-            # * https://github.com/ContinuumIO/anaconda-issues/issues/10082
-            # * https://github.com/conda/conda/issues/7789
-            res = "https://repo.continuum.io/miniconda/Miniconda$(MINICONDA_VERSION)-4.5.4-"
-        end
         res *= "Windows"
     else
         error("Unsuported OS.")
@@ -143,7 +136,7 @@ function _installer_url()
 
     # mapping of Julia architecture names to Conda architecture names, where they differ
     arch2conda = Dict(:i686 => :x86)
-    
+
     if Sys.ARCH in (:i686, :x86_64, :ppc64le)
         res *= string('-', get(arch2conda, Sys.ARCH, Sys.ARCH))
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ rm(Conda.prefix(env); force=true, recursive=true)
 Conda.add("curl", env)
 
 @testset "Install Python package" begin
-    Conda.add("python=3.6", env)  # 3.7 doesn't work on Windows at the moment
+    Conda.add("python", env)
     pythonpath = joinpath(Conda.python_dir(env), "python" * exe)
     @test isfile(pythonpath)
 


### PR DESCRIPTION
Reverts #124, which was a "temporary" workaround from 2 years ago that we forgot about, and is now breaking things on Windows — it pins the Windows Python at 3.6, which nowadays seems to be broken.

cc @tkf, @ranjanan