### PR TITLE
Added pip support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Conda"
 uuid = "8f4d0f93-b110-5947-807f-2305c1781a2d"
-version = "1.4.1"
+version = "1.5.0"
 
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Once Conda is installed, you can run `import Conda` to load the package and run 
 - `Conda.add_channel(channel, env)`: add a channel to the list of channels;
 - `Conda.channels(env)`: get the current list of channels;
 - `Conda.rm_channel(channel, env)`: remove a channel from the list of channels;
+- **experimental:** read the section **Conda and pip** below before using the following
+    - `Conda.pip_interop(bool, env)`: config environment to interact with `pip`
+    - `Conda.pip(command, package, env)`: run `pip` command on packages in environment
 
 The parameter `env` is optional and defaults to `ROOTENV`. See below for more info.
 
@@ -78,6 +81,24 @@ julia> ENV["CONDA_JL_HOME"] = "/path/to/miniconda/envs/conda_jl"  # change this 
 
 pkg> build Conda
 ```
+
+## Conda and pip
+As of [conda 4.6.0](https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/pip-interoperability.html#improving-interoperability-with-pip) there is improved support for PyPi packages.
+**Conda is still the recommended installation method** however if there are packages that are only availible with `pip` one can do the following:
+
+```jl
+julia> Conda.pip_interop(true, env)
+
+julia> Conda.pip("install", "somepackage")
+
+julia> Conda.pip("install", ["somepackage1", "somepackage2"])
+
+julia> Conda.pip("uninstall", "somepackage")
+
+julia> Conda.pip("uninstall", ["somepackage1", "somepackage2])
+```
+
+If the uninstall command is to be used noninteractively, one can use `"uninstall -y"` to answer yes to the prompts.
 
 ## Using Python 2
 By default, the Conda.jl package [installs Python 3]((https://conda.io/docs/py2or3.htm)),

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,11 +21,11 @@ branches:
     - master
     - /release-.*/
 
-notifications:
-  - provider: Email
-    on_build_success: false
-    on_build_failure: true
-    on_build_status_changed: true
+# notifications:
+#   - provider: Email
+#     on_build_success: false
+#     on_build_failure: true
+#     on_build_status_changed: true
 
 install:
   - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -398,6 +398,7 @@ function check_pip_interop(env::Environment=ROOTENV)
                               """)
 end
 
+"pip command to use for specified environment"
 function _pip(env::Environment)
     "pip" ∉ _installed_packages(env) && add("pip", env)
     joinpath(bin_dir(env), "pip")
@@ -405,11 +406,10 @@ end
 
 function pip(cmd::AbstractString, pkgs::PkgOrPkgs, env::Environment=ROOTENV)
     check_pip_interop(env)
+    # parse the pip command
     _cmd = String[split(cmd, " ")...]
     @info("Running $(`pip $_cmd $pkgs`) in $(env==ROOTENV ? "root" : env) environment")
-    env_var = _get_conda_env(env)
-    
-    run(setenv(`$(_pip(env)) $_cmd $pkgs`, env_var))
+    run(_set_conda_env(`$(_pip(env)) $_cmd $pkgs`, env))
     nothing
 end
 

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -47,8 +47,7 @@ const PREFIX = prefix(ROOTENV)
 
 "Prefix for the executable files installed with the packages"
 function bin_dir(env::Environment)
-    return joinpath(prefix(env), "bin")
-    #return Sys.iswindows() ? joinpath(prefix(env), "Library", "bin") : joinpath(prefix(env), "bin")
+    return Sys.iswindows() ? joinpath(prefix(env), "Library", "bin") : joinpath(prefix(env), "bin")
 end
 const BINDIR = bin_dir(ROOTENV)
 
@@ -402,7 +401,7 @@ end
 "pip command to use for specified environment"
 function _pip(env::Environment)
     "pip" ∉ _installed_packages(env) && add("pip", env)
-    joinpath(bin_dir(env), "pip")
+    joinpath(python_dir(env), "pip")
 end
 
 function pip(cmd::AbstractString, pkgs::PkgOrPkgs, env::Environment=ROOTENV)

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -401,7 +401,8 @@ end
 "pip command to use for specified environment"
 function _pip(env::Environment)
     "pip" ∉ _installed_packages(env) && add("pip", env)
-    joinpath(python_dir(env), "pip")
+    pipstr = Sys.iswindows() ? "pip.exe" : "pip"
+    joinpath(script_dir(env), pipstr)
 end
 
 function pip(cmd::AbstractString, pkgs::PkgOrPkgs, env::Environment=ROOTENV)

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -47,7 +47,8 @@ const PREFIX = prefix(ROOTENV)
 
 "Prefix for the executable files installed with the packages"
 function bin_dir(env::Environment)
-    return Sys.iswindows() ? joinpath(prefix(env), "Library", "bin") : joinpath(prefix(env), "bin")
+    return joinpath(prefix(env), "bin")
+    #return Sys.iswindows() ? joinpath(prefix(env), "Library", "bin") : joinpath(prefix(env), "bin")
 end
 const BINDIR = bin_dir(ROOTENV)
 

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -398,11 +398,12 @@ function check_pip_interop(env::Environment=ROOTENV)
                               """)
 end
 
+_pip() = Sys.iswindows() ? "pip.exe" : "pip"
+
 "pip command to use for specified environment"
 function _pip(env::Environment)
     "pip" ∉ _installed_packages(env) && add("pip", env)
-    pipstr = Sys.iswindows() ? "pip.exe" : "pip"
-    joinpath(script_dir(env), pipstr)
+    joinpath(script_dir(env), _pip())
 end
 
 function pip(cmd::AbstractString, pkgs::PkgOrPkgs, env::Environment=ROOTENV)

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -388,7 +388,7 @@ Gets the `pip_interop_enabled` value from the conda config.
 """
 function pip_interop(env::Environment=ROOTENV)
     dict = parseconda(`config --get pip_interop_enabled --file $(conda_rc(env))`, env)["get"]
-    isempty(dict) ? false : dict["pip_interop_enabled"]
+    get(dict, "pip_interop_enabled", false)
 end
 
 function check_pip_interop(env::Environment=ROOTENV)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,3 +91,30 @@ Conda.clean(; debug=true)
     @test "curl" ∈ installed
     rm("conda-pkg.txt")
 end
+
+@testset "Conda.pip_interop" begin
+    Conda.pip_interop(false, env)
+    @test_throws Exception Conda.check_pip_interop(env)
+    @test !Conda.pip_interop(env)
+
+    Conda.pip_interop(true, env)
+    @test Conda.pip_interop(env)
+    @test Conda.check_pip_interop(env)
+end
+
+@testset "Conda.pip" begin
+    Conda.pip("install", "affine", env)
+    @test "affine" ∈ Conda._installed_packages(env)
+    Conda.pip("uninstall -y", "affine", env)
+    @test "affine" ∉ Conda._installed_packages(env)
+
+    Conda.pip("install", ["affine", "ansi2html"], env)
+    installed = Conda._installed_packages(env)
+    @test "affine" ∈ installed
+    @test "ansi2html" ∈ installed
+
+    Conda.pip("uninstall -y", ["affine", "ansi2html"], env)
+    installed = Conda._installed_packages(env)
+    @test "affine" ∉ installed
+    @test "ansi2html" ∉ installed
+end


### PR DESCRIPTION
As of [conda 4.6.0](https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/pip-interoperability.html#improving-interoperability-with-pip) there is more interoperability with pip. This pull request adds
```julia
Conda.pip_interop(bool::Bool, env::Environment=ROOTENV)
```
which can "enable" or "disable" the interoperability setting and
```julia
Conda.pip(cmd::AbstractString, pkgs::PkgOrPkgs, env::Environment=ROOTENV)
```
where `cmd` is `install`, `uninstall`, or other supported `pip` commands (although only `install` and `uninstall` have been thoroughly tested). The `pip` command is run within the specified environment. Tests have been added to `runtests.jl` that validate that they are indeed installed to the correct environment. The `README.md` has been updated to include this addition functionality.

This should close #50 