### PR TITLE
Make ROOTENV always include MINICONDA_VERSION

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,8 @@ VersionParsing = "1"
 julia = "1"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Pkg", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -7,9 +7,9 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 VersionParsing = "81def892-9a0e-5fdd-b105-ffc91e053289"
 
 [compat]
-julia = "1"
 JSON = "0.18,0.19,0.20,0.21"
 VersionParsing = "1"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -20,7 +20,7 @@ ROOTENV = get(ENV, "CONDA_JL_HOME") do
     root = DefaultDeps.ROOTENV
 
     # Ensure the ROOTENV uses the current MINICONDA_VERSION when not using a custom ROOTENV
-    if normpath(dirname(root)) == normpath(condadir) && all(isdigit, basename(root)) && basename(root) != MINICONDA_VERSION
+    if normpath(dirname(root)) == normpath(condadir) && all(isdigit, basename(root))
         joinpath(condadir, MINICONDA_VERSION)
     else
         root

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -17,11 +17,13 @@ end
 
 MINICONDA_VERSION = get(ENV, "CONDA_JL_VERSION", DefaultDeps.MINICONDA_VERSION)
 ROOTENV = get(ENV, "CONDA_JL_HOME") do
+    root = DefaultDeps.ROOTENV
+
     # Ensure the ROOTENV uses the current MINICONDA_VERSION when not using a custom ROOTENV
-    if abspath(dirname(DefaultDeps.ROOTENV)) == condadir
+    if normpath(dirname(root)) == normpath(condadir) && all(isdigit, basename(root)) && basename(root) != MINICONDA_VERSION
         joinpath(condadir, MINICONDA_VERSION)
     else
-        DefaultDeps.ROOTENV
+        root
     end
 end
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -15,8 +15,15 @@ module DefaultDeps
     end
 end
 
-ROOTENV = get(ENV, "CONDA_JL_HOME", DefaultDeps.ROOTENV)
 MINICONDA_VERSION = get(ENV, "CONDA_JL_VERSION", DefaultDeps.MINICONDA_VERSION)
+ROOTENV = get(ENV, "CONDA_JL_HOME") do
+    # Ensure the ROOTENV uses the current MINICONDA_VERSION when not using a custom ROOTENV
+    if abspath(dirname(DefaultDeps.ROOTENV)) == condadir
+        joinpath(condadir, MINICONDA_VERSION)
+    else
+        DefaultDeps.ROOTENV
+    end
+end
 
 if isdir(ROOTENV) && MINICONDA_VERSION != DefaultDeps.MINICONDA_VERSION
     error("""Miniconda version changed, since last build.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -147,7 +147,7 @@ end
         preserve_build() do
             # Mismatch in written file
             write(depsfile, """
-                const ROOTENV = "$(joinpath(condadir, "3"))"
+                const ROOTENV = "$(escape_string(joinpath(condadir, "3")))"
                 const MINICONDA_VERSION = "2"
                 """)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,7 +122,7 @@ end
             withenv("CONDA_JL_VERSION" => nothing, "CONDA_JL_HOME" => nothing) do
                 Pkg.build("Conda")
                 @test read(depsfile, String) == """
-                    const ROOTENV = "$(joinpath(condadir, "3"))"
+                    const ROOTENV = "$(escape_string(joinpath(condadir, "3")))"
                     const MINICONDA_VERSION = "3"
                     """
             end
@@ -135,7 +135,7 @@ end
                 withenv("CONDA_JL_VERSION" => "3", "CONDA_JL_HOME" => dir) do
                     Pkg.build("Conda")
                     @test read(depsfile, String) == """
-                        const ROOTENV = "$dir"
+                        const ROOTENV = "$(escape_string(dir))"
                         const MINICONDA_VERSION = "3"
                         """
                 end
@@ -154,7 +154,7 @@ end
             withenv("CONDA_JL_VERSION" => nothing, "CONDA_JL_HOME" => nothing) do
                 Pkg.build("Conda")
                 @test read(depsfile, String) == """
-                    const ROOTENV = "$(joinpath(condadir, "2"))"
+                    const ROOTENV = "$(escape_string(joinpath(condadir, "2")))"
                     const MINICONDA_VERSION = "2"
                     """
             end
@@ -163,7 +163,7 @@ end
             withenv("CONDA_JL_VERSION" => "3", "CONDA_JL_HOME" => nothing) do
                 Pkg.build("Conda")
                 @test read(depsfile, String) == """
-                    const ROOTENV = "$(joinpath(condadir, "3"))"
+                    const ROOTENV = "$(escape_string(joinpath(condadir, "3")))"
                     const MINICONDA_VERSION = "3"
                     """
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Conda, VersionParsing, Test
+using Conda, Pkg, Test, VersionParsing
 
 exe = Sys.iswindows() ? ".exe" : ""
 
@@ -90,4 +90,78 @@ Conda.clean(; debug=true)
     installed = Conda._installed_packages(new_env)
     @test "curl" ∈ installed
     rm("conda-pkg.txt")
+end
+
+@testset "build" begin
+    condadir = abspath(first(DEPOT_PATH), "conda")
+    depsfile = joinpath(@__DIR__, "..", "deps", "deps.jl")
+
+    function preserve_build(body)
+        condadir_bak = condadir * "-backup"
+        depsfile_bak = depsfile * "-backup"
+
+        # Backup contents that may be changed by a build.
+        ispath(condadir) && mv(condadir, condadir_bak)
+        ispath(depsfile) && mv(depsfile, depsfile_bak)
+
+        try
+            body()
+        finally
+            # Restore content
+            ispath(condadir_bak) && mv(condadir_bak, condadir; force=true)
+            ispath(depsfile_bak) && mv(depsfile_bak, depsfile; force=true)
+        end
+    end
+
+    @testset "defaults" begin
+        preserve_build() do
+            # In order to test the defaults no depsfiles must be present
+            @test !isfile(depsfile)
+            @test !isfile(joinpath(condadir, "deps.jl"))
+
+            Pkg.build("Conda")
+            @test read(depsfile, String) == """
+                const ROOTENV = "$(joinpath(condadir, "3"))"
+                const MINICONDA_VERSION = "3"
+                """
+        end
+    end
+
+    @testset "custom home" begin
+        preserve_build() do
+            mktempdir() do dir
+                withenv("CONDA_JL_HOME" => dir) do
+                    Pkg.build("Conda")
+                    @test read(depsfile, String) == """
+                        const ROOTENV = "$dir"
+                        const MINICONDA_VERSION = "3"
+                        """
+                end
+            end
+        end
+    end
+
+    @testset "version mismatch" begin
+        preserve_build() do
+            # Mismatch in written file
+            write(depsfile, """
+                const ROOTENV = "$(joinpath(condadir, "3"))"
+                const MINICONDA_VERSION = "2"
+                """)
+            Pkg.build("Conda")
+            @test read(depsfile, String) == """
+                const ROOTENV = "$(joinpath(condadir, "2"))"
+                const MINICONDA_VERSION = "2"
+                """
+
+            # ROOTENV should be replaced since CONDA_JL_HOME wasn't explicitly set
+            withenv("CONDA_JL_VERSION" => "3") do
+                Pkg.build("Conda")
+                @test read(depsfile, String) == """
+                    const ROOTENV = "$(joinpath(condadir, "3"))"
+                    const MINICONDA_VERSION = "3"
+                    """
+            end
+        end
+    end
 end


### PR DESCRIPTION
I encountered a scenario in which my Conda `deps.jl` file contained:
```julia
const ROOTENV = "/Users/omus/.julia/conda/3"
const MINICONDA_VERSION = "2"
```
I expect with this configuration that my `ROOTENV` included Miniconda 2 packages even though the `ROOTENV` appears to be for version 3. As this is confusing I updated the package to always create `ROOTENV` from a combination of the current `CONDA_HOME` and `MINICONDA_VERSION`. Doing this should avoid any confusion and additionally allow users to switch between Miniconda versions without having to delete the `ROOTENV` first.