### PR TITLE
Allow downloading miniconda from alternative url

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ julia> ENV["CONDA_JL_HOME"] = "/path/to/miniconda/envs/conda_jl"  # change this 
 pkg> build Conda
 ```
 
+## Retrieving Miniconda from an alternative location
+
+If you need to download Miniconda from an alternative location, for example if you are behind a corporate firewall that forbids you internet access but it has conda available in the local network, you can set the `CONDA_JL_BASEURL` variable prior to installing `Conda`. For example:
+
+``` jl
+julia> ENV["CONDA_JL_BASEURL"] = "https://miniconda-mirror.intranet.net/miniconda"
+```
+
+This will retrieve Miniconda installation archive from your intranet location.
+
 ## Conda and pip
 As of [conda 4.6.0](https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/pip-interoperability.html#improving-interoperability-with-pip) there is improved support for PyPi packages.
 **Conda is still the recommended installation method** however if there are packages that are only availible with `pip` one can do the following:

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -82,6 +82,9 @@ end
 conda_rc(env::Environment) = joinpath(prefix(env), "condarc-julia.yml")
 const CONDARC = conda_rc(ROOTENV)
 
+"Default base URL to download Conda from"
+const MINICONDA_DEFAULT_BASE_URL = "https://repo.continuum.io/miniconda"
+
 """
 Get a cleaned up environment
 
@@ -123,9 +126,12 @@ function parseconda(args::Cmd, env::Environment=ROOTENV)
     JSON.parse(read(_set_conda_env(`$conda $args --json`, env), String))
 end
 
+"Retrieve Miniconda base url. This is the directory That would contain Miniconda-$(MINICONDA_VERSION)-latest-[...]"
+_miniconda_base_url() = get(ENV, "CONDA_JL_BASEURL", MINICONDA_DEFAULT_BASE_URL)
+
 "Get the miniconda installer URL."
 function _installer_url()
-    res = "https://repo.continuum.io/miniconda/Miniconda$(MINICONDA_VERSION)-latest-"
+    res = _miniconda_base_url() * "/Miniconda$(MINICONDA_VERSION)-latest-"
     if Sys.isapple()
         res *= "MacOSX"
     elseif Sys.islinux()

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -83,7 +83,7 @@ conda_rc(env::Environment) = joinpath(prefix(env), "condarc-julia.yml")
 const CONDARC = conda_rc(ROOTENV)
 
 "Default base URL to download Conda from"
-const MINICONDA_DEFAULT_BASE_URL = "https://repo.continuum.io/miniconda"
+const MINICONDA_DEFAULT_BASEURL = "https://repo.continuum.io/miniconda"
 
 """
 Get a cleaned up environment
@@ -127,7 +127,7 @@ function parseconda(args::Cmd, env::Environment=ROOTENV)
 end
 
 "Retrieve Miniconda base url. This is the directory That would contain Miniconda-$(MINICONDA_VERSION)-latest-[...]"
-_miniconda_base_url() = get(ENV, "CONDA_JL_BASEURL", MINICONDA_DEFAULT_BASE_URL)
+_miniconda_base_url() = get(ENV, "CONDA_JL_BASEURL", MINICONDA_DEFAULT_BASEURL)
 
 "Get the miniconda installer URL."
 function _installer_url()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -201,10 +201,10 @@ end
 # Test that setting CONDA_JL_BASEURL environment variable has effect
 @testset "Conda Base URL" begin
     withenv("CONDA_JL_BASEURL" => nothing) do
-        @test Conda._miniconda_base_url() == Conda.MINICONDA_DEFAULT_BASE_URL
+        @test Conda._miniconda_base_url() == Conda.MINICONDA_DEFAULT_BASEURL
     end
 
-    testurl = Conda.MINICONDA_DEFAULT_BASE_URL * "/"
+    testurl = Conda.MINICONDA_DEFAULT_BASEURL * "/"
     withenv("CONDA_JL_BASEURL" => testurl) do
         @test Conda._miniconda_base_url() == testurl
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -197,3 +197,15 @@ end
         end
     end
 end
+
+# Test that setting CONDA_JL_BASEURL environment variable has effect
+@testset "Conda Base URL" begin
+    withenv("CONDA_JL_BASEURL" => nothing) do
+        @test Conda._miniconda_base_url() == Conda.MINICONDA_DEFAULT_BASE_URL
+    end
+
+    testurl = Conda.MINICONDA_DEFAULT_BASE_URL * "/"
+    withenv("CONDA_JL_BASEURL" => testurl) do
+        @test Conda._miniconda_base_url() == testurl
+    end
+end


### PR DESCRIPTION
I am behind a corporate firewall with no direct access to internet.
However, we do have a local URL with miniconda sources and binaries.
The current PR allows one to set `CONDA_JL_BASEURL` environment variable and use that value for downloading miniconda.