### PR TITLE
Fix `download` deprecation for Julia 1.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Conda"
 uuid = "8f4d0f93-b110-5947-807f-2305c1781a2d"
-version = "1.5.2"
+version = "1.5.3"
 
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -14,7 +14,16 @@ The main functions in Conda are:
 ```
 """
 module Conda
-using JSON, VersionParsing
+
+using JSON
+using VersionParsing
+
+if VERSION >= v"1.6.0-DEV.923"
+    # Use Downloads.jl once Conda.jl drops support for Julia versions < 1.3
+    download(args...) = Base.invokelatest(Base.Downloads().download, args...)
+else
+    using Base: download
+end
 
 const deps_file = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
 


### PR DESCRIPTION
Closes #202 

Similar to workaround in https://github.com/JuliaTime/TimeZones.jl/pull/339