### PR TITLE
Define DEFAULT_ENV based on CONDA_JL_DEFAULTENV environmental variable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Conda"
 uuid = "8f4d0f93-b110-5947-807f-2305c1781a2d"
-version = "1.6"
+version = "2.0"
 
 [deps]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -52,10 +52,16 @@ These will require rebuilding.
 """)
 end
 
+# New as of Conda.jl 2.0
+# Allows setting a default environment other than rootenv
+# Defaults to to ROOTENV
+DEFAULTENV = get(ENV, "CONDA_JL_DEFAULTENV", ROOTENV)
+
 deps = """
 const ROOTENV = "$(escape_string(ROOTENV))"
 const MINICONDA_VERSION = "$(escape_string(MINICONDA_VERSION))"
 const USE_MINIFORGE = $USE_MINIFORGE
+const DEFAULTENV = "$(escape_string(DEFAULTENV))"
 """
 
 mkpath(condadir)


### PR DESCRIPTION
This creates a new constant, `DEFAULTENV`, that can be set by the environmental variable `CONDA_JL_DEFAULTENV` at build time.
`ROOTENV` refers to the base environment which contains `conda`. This defines `Conda.conda` and where to install conda.
`DEFAULTENV` is the default environment, which may be a sub-environment of `ROOTENV` (e.g. in `$ROOTENV/envs`) which serves as the default environment for most of the functions.

If `CONDA_JL_DEFAULTENV` does not exist at build time, then `DEFAULTENV` will be set to `ROOTENV`.

Since it is possible that a legacy deps.jl may not set `DEFAULTENV`, the existence of `DEFAULTENV` is also checked at compile time. In this case `DEFAULTENV` is set to `ROOTENV`.


