### PR TITLE
Introduce CONDA_JL_CONDA_EXE environment variable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Conda"
 uuid = "8f4d0f93-b110-5947-807f-2305c1781a2d"
-version = "1.6"
+version = "1.7"
 
 [deps]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 [![Build Status](https://github.com/JuliaPy/Conda.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/JuliaPy/Conda.jl/actions/workflows/CI.yml)
 
 This package allows one to use [conda](http://conda.pydata.org/) as a cross-platform binary provider for Julia for other Julia packages,
-especially to install binaries that have complicated dependencies
-like Python.
+especially to install binaries that have complicated dependencies like Python.
 
 `conda` is a package manager which started as the binary package manager for the
 Anaconda Python distribution, but it also provides arbitrary packages. Instead
@@ -80,6 +79,20 @@ julia> ENV["CONDA_JL_HOME"] = "/path/to/miniconda/envs/conda_jl"  # change this 
 
 pkg> build Conda
 ```
+
+## Using a conda executable outside of the home environment
+To use a specific conda executable, set the `CONDA_JL_CONDA_EXE` environment
+variable to the location of the conda executable. This conda executable can
+exist outside of the environment set by `CONDA_JL_HOME`. To apply the settting,
+rebuild `Conda.jl`. In Julia, run:
+
+```jl
+julia> ENV["CONDA_JL_CONDA_EXE"] = "/path/to/miniconda/bin/conda" # change this to the path of the conda executable
+
+pkg> build Conda
+```
+
+*The use of `CONDA_JL_CONDA_EXE` requires at least version 1.7 of Conda.jl.*
 
 ## Conda and pip
 As of [conda 4.6.0](https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/pip-interoperability.html#improving-interoperability-with-pip) there is improved support for PyPi packages.

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -26,7 +26,7 @@ Using the Anaconda/defaults channel instead, which is free for non-commercial us
     end
     function default_conda_exe(ROOTENV)
         @static if Sys.iswindows()
-            p = joinpath(ROOTENV, "Script")
+            p = joinpath(ROOTENV, "Scripts")
             conda_bat = joinpath(p, "conda.bat")
             isfile(conda_bat) ? conda_bat : joinpath(p, "conda.exe")
         else

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -79,12 +79,19 @@ if haskey(ENV, "CONDA_JL_CONDA_EXE")
         if uperm(CONDA_EXE) & 0x01 > 0
             @info "Executable conda located." CONDA_EXE
         else
-            error("$CONDA_EXE cannot be executed by the current user.")
+            error("CONDA_JL_CONDA_EXE, $CONDA_EXE, cannot be executed by the current user.")
         end
     else
-        error("$CONDA_EXE does not exist.")
+        error("CONDA_JL_CONDA_EXE, $CONDA_EXE, does not exist.")
+    end
+else
+    if !isfile(CONDA_EXE)
+        # An old CONDA_EXE has gone missing, revert to default in ROOTENV
+        @info "CONDA_EXE not found. Reverting to default in ROOTENV" CONDA_EXE ROOTENV
+        CONDA_EXE = DefaultDeps.default_conda_exe(ROOTENV)
     end
 end
+
 
 deps = """
 const ROOTENV = "$(escape_string(ROOTENV))"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -24,6 +24,16 @@ Using the Anaconda/defaults channel instead, which is free for non-commercial us
     if !isdefined(@__MODULE__, :USE_MINIFORGE)
         const USE_MINIFORGE = USE_MINIFORGE_DEFAULT
     end
+    if !isdefined(@__MODULE__, :CONDA_EXE)
+        const CONDA_EXE = if Sys.iswindows()
+            p = joinpath(ROOTENV, "Script")
+            conda_bat = joinpath(p, "conda.bat")
+            isfile(conda_bat) ? conda_bat : joinpath(p, "conda.exe")
+        else
+            joinpath(ROOTENV, "bin", "conda")
+        end
+
+    end
 end
 
 MINICONDA_VERSION = get(ENV, "CONDA_JL_VERSION", DefaultDeps.MINICONDA_VERSION)
@@ -52,10 +62,13 @@ These will require rebuilding.
 """)
 end
 
+CONDA_EXE = get(ENV, "CONDA_JL_CONDA_EXE", DefaultDeps.CONDA_EXE)
+
 deps = """
 const ROOTENV = "$(escape_string(ROOTENV))"
 const MINICONDA_VERSION = "$(escape_string(MINICONDA_VERSION))"
 const USE_MINIFORGE = $USE_MINIFORGE
+const CONDA_EXE = "$(escape_string(CONDA_EXE))"
 """
 
 mkpath(condadir)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -76,7 +76,7 @@ end
 if haskey(ENV, "CONDA_JL_CONDA_EXE")
     # Check to see if CONDA_EXE is an executable file
     if isfile(CONDA_EXE)
-        if uperm(CONDA_EXE) & 0x01 > 0
+        if Sys.isexecutable(CONDA_EXE)
             @info "Executable conda located." CONDA_EXE
         else
             error("CONDA_JL_CONDA_EXE, $CONDA_EXE, cannot be executed by the current user.")

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -73,6 +73,19 @@ CONDA_EXE = get(ENV, "CONDA_JL_CONDA_EXE") do
     end
 end
 
+if haskey(ENV, "CONDA_JL_CONDA_EXE")
+    # Check to see if CONDA_EXE is an executable file
+    if isfile(CONDA_EXE)
+        if uperm(CONDA_EXE) & 0x01 > 0
+            @info "Executable conda located." CONDA_EXE
+        else
+            error("$CONDA_EXE cannot be executed by the current user.")
+        end
+    else
+        error("$CONDA_EXE does not exist.")
+    end
+end
+
 deps = """
 const ROOTENV = "$(escape_string(ROOTENV))"
 const MINICONDA_VERSION = "$(escape_string(MINICONDA_VERSION))"

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -189,24 +189,21 @@ _quiet() = get(ENV, "CI", "false") == "true" ? `-q` : ``
 "Install miniconda if it hasn't been installed yet; _install_conda(true) installs Conda even if it has already been installed."
 function _install_conda(env::Environment, force::Bool=false)
     if force || !isfile(Conda.conda)
-        # This assumes that the conda executable will in some directory under
-        # CONDA_EXE_PREFIX.
-        # Ex: If CONDA_EXE="$HOME/miniforge3/bin/conda", then CONDA_EXE_PREFIX="$HOME/miniforge3"
-        CONDA_EXE_PREFIX = conda |> dirname |> dirname
+        @assert startswith(abspath(Conda.conda), abspath(PREFIX)) "CONDA_EXE, $(conda), does not exist within $PREFIX"
         @info("Downloading miniconda installer ...")
         if Sys.isunix()
-            installer = joinpath(CONDA_EXE_PREFIX, "installer.sh")
+            installer = joinpath(PREFIX, "installer.sh")
         end
         if Sys.iswindows()
-            installer = joinpath(CONDA_EXE_PREFIX, "installer.exe")
+            installer = joinpath(PREFIX, "installer.exe")
         end
-        mkpath(CONDA_EXE_PREFIX)
+        mkpath(PREFIX)
         Downloads.download(_installer_url(), installer)
 
         @info("Installing miniconda ...")
         if Sys.isunix()
             chmod(installer, 33261)  # 33261 corresponds to 755 mode of the 'chmod' program
-            run(`$installer -b -f -p $CONDA_EXE_PREFIX`)
+            run(`$installer -b -f -p $PREFIX`)
         end
         if Sys.iswindows()
             run(Cmd(`$installer /S --no-shortcuts /NoRegistry=1 /AddToPath=0 /RegisterPython=0 /D=$PREFIX`, windows_verbatim=true))

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -213,7 +213,7 @@ function _install_conda(env::Environment, force::Bool=false)
         end
     end
     if !isdir(prefix(env))
-        runconda(`create $(_quiet()) -y -p $(prefix(env))`)
+        create(env)
     end
 end
 
@@ -228,6 +228,10 @@ end
 "Uninstall a package or packages."
 function rm(pkg::PkgOrPkgs, env::Environment=ROOTENV)
     runconda(`remove $(_quiet()) -y $pkg`, env)
+end
+
+function create(env::Environment)
+    runconda(`create $(_quiet()) -y -p $(prefix(env))`)
 end
 
 "Update all installed packages."

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -72,13 +72,7 @@ const PYTHONDIR = python_dir(ROOTENV)
 
 if ! @isdefined(CONDA_EXE)
     # We have an oudated deps.jl file that does not define CONDA_EXE
-    const CONDA_EXE = if Sys.iswindows()
-        p = script_dir(ROOTENV)
-        conda_bat = joinpath(p, "conda.bat")
-        isfile(conda_bat) ? conda_bat : joinpath(p, "conda.exe")
-    else
-        joinpath(bin_dir(ROOTENV), "conda")
-    end
+    error("CONDA_EXE not defined in $deps_file.\nPlease rebuild Conda.jl via `using Pkg; pkg\"build Conda\";`")
 end
 # note: the same conda program is used for all environments
 const conda = CONDA_EXE

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -158,7 +158,7 @@ end
 
     function default_conda_exe(ROOTENV)
         @static if Sys.iswindows()
-            p = joinpath(ROOTENV, "Script")
+            p = joinpath(ROOTENV, "Scripts")
             conda_bat = joinpath(p, "conda.bat")
             isfile(conda_bat) ? conda_bat : joinpath(p, "conda.exe")
         else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -235,7 +235,7 @@ end
             mktempdir() do dir
                 withenv("CONDA_JL_VERSION" => "3", "CONDA_JL_HOME" => dir, "CONDA_JL_USE_MINIFORGE" => nothing, "CONDA_JL_CONDA_EXE" => nothing) do
                     Pkg.build("Conda")
-                    let CONDA_EXE=default_conda_exe(ROOTENV)
+                    let CONDA_EXE=default_conda_exe(dir)
                     @test read(depsfile, String) == """
                         const ROOTENV = "$(escape_string(dir))"
                         const MINICONDA_VERSION = "3"
@@ -253,10 +253,10 @@ end
             # Mismatch in written file
             let ROOTENV=joinpath(condadir, "3"), CONDA_EXE=default_conda_exe(ROOTENV)
             write(depsfile, """
-                const ROOTENV = "$(escape_string(ROOTENV)))"
+                const ROOTENV = "$(escape_string(ROOTENV))"
                 const MINICONDA_VERSION = "2"
                 const USE_MINIFORGE = $(CONDA_JL_USE_MINIFORGE_DEFAULT)
-                const CONDA_EXE = "$(escape_string(CONDA_EXE)))"
+                const CONDA_EXE = "$(escape_string(CONDA_EXE))"
                 """)
             end
 
@@ -277,7 +277,7 @@ end
                 Pkg.build("Conda")
                 let ROOTENV=joinpath(condadir, "3"), CONDA_EXE=default_conda_exe(ROOTENV)
                 @test read(depsfile, String) == """
-                    const ROOTENV = "$(escape_string(ROOTENV)))"
+                    const ROOTENV = "$(escape_string(ROOTENV))"
                     const MINICONDA_VERSION = "3"
                     const USE_MINIFORGE = $(CONDA_JL_USE_MINIFORGE_DEFAULT)
                     const CONDA_EXE = "$(escape_string(CONDA_EXE))"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -181,14 +181,14 @@ end
 
             withenv("CONDA_JL_VERSION" => nothing, "CONDA_JL_HOME" => nothing, "CONDA_JL_USE_MINIFORGE" => nothing, "CONDA_JL_CONDA_EXE" => nothing) do
                 Pkg.build("Conda")
-                let ROOTENV=joinpath(condadir, "3"), CONDA_EXE=default_conda_exe(ROOTENV)
+                local ROOTENV=joinpath(condadir, "3")
+                local CONDA_EXE=default_conda_exe(ROOTENV)
                 @test read(depsfile, String) == """
                     const ROOTENV = "$(escape_string(ROOTENV))"
                     const MINICONDA_VERSION = "3"
                     const USE_MINIFORGE = $(CONDA_JL_USE_MINIFORGE_DEFAULT)
                     const CONDA_EXE = "$(escape_string(CONDA_EXE))"
                     """
-                end
             end
         end
     end
@@ -201,14 +201,14 @@ end
 
             withenv("CONDA_JL_VERSION" => nothing, "CONDA_JL_HOME" => nothing, "CONDA_JL_USE_MINIFORGE" => "1", "CONDA_JL_CONDA_EXE" => nothing) do
                 Pkg.build("Conda")
-                let ROOTENV=joinpath(condadir, "3"), CONDA_EXE=default_conda_exe(ROOTENV)
+                local ROOTENV=joinpath(condadir, "3")
+                local CONDA_EXE=default_conda_exe(ROOTENV)
                 @test read(depsfile, String) == """
                     const ROOTENV = "$(escape_string(joinpath(condadir, "3")))"
                     const MINICONDA_VERSION = "3"
                     const USE_MINIFORGE = true
                     const CONDA_EXE = "$(escape_string(CONDA_EXE))"
                     """
-                end
             end
         end
         preserve_build() do
@@ -218,14 +218,14 @@ end
 
             withenv("CONDA_JL_VERSION" => nothing, "CONDA_JL_HOME" => nothing, "CONDA_JL_USE_MINIFORGE" => "0", "CONDA_JL_CONDA_EXE" => nothing) do
                 Pkg.build("Conda")
-                let ROOTENV=joinpath(condadir, "3"), CONDA_EXE=default_conda_exe(ROOTENV)
+                local ROOTENV=joinpath(condadir, "3")
+                local CONDA_EXE=default_conda_exe(ROOTENV)
                 @test read(depsfile, String) == """
                     const ROOTENV = "$(escape_string(ROOTENV))"
                     const MINICONDA_VERSION = "3"
                     const USE_MINIFORGE = false
                     const CONDA_EXE = "$(escape_string(CONDA_EXE))"
                     """
-                end
             end
         end
     end
@@ -235,14 +235,13 @@ end
             mktempdir() do dir
                 withenv("CONDA_JL_VERSION" => "3", "CONDA_JL_HOME" => dir, "CONDA_JL_USE_MINIFORGE" => nothing, "CONDA_JL_CONDA_EXE" => nothing) do
                     Pkg.build("Conda")
-                    let CONDA_EXE=default_conda_exe(dir)
+                    local CONDA_EXE=default_conda_exe(dir)
                     @test read(depsfile, String) == """
                         const ROOTENV = "$(escape_string(dir))"
                         const MINICONDA_VERSION = "3"
                         const USE_MINIFORGE = $(CONDA_JL_USE_MINIFORGE_DEFAULT)
                         const CONDA_EXE = "$(escape_string(CONDA_EXE))"
                         """
-                    end
                 end
             end
         end
@@ -251,38 +250,38 @@ end
     @testset "version mismatch" begin
         preserve_build() do
             # Mismatch in written file
-            let ROOTENV=joinpath(condadir, "3"), CONDA_EXE=default_conda_exe(ROOTENV)
+            local ROOTENV=joinpath(condadir, "3")
+            local CONDA_EXE=default_conda_exe(ROOTENV)
             write(depsfile, """
                 const ROOTENV = "$(escape_string(ROOTENV))"
                 const MINICONDA_VERSION = "2"
                 const USE_MINIFORGE = $(CONDA_JL_USE_MINIFORGE_DEFAULT)
                 const CONDA_EXE = "$(escape_string(CONDA_EXE))"
                 """)
-            end
 
             withenv("CONDA_JL_VERSION" => nothing, "CONDA_JL_HOME" => nothing, "CONDA_JL_USE_MINIFORGE" => nothing, "CONDA_JL_CONDA_EXE" => nothing) do
                 Pkg.build("Conda")
-                let ROOTENV=joinpath(condadir, "2"), CONDA_EXE=default_conda_exe(ROOTENV)
+                local ROOTENV=joinpath(condadir, "2")
+                local CONDA_EXE=default_conda_exe(ROOTENV)
                 @test read(depsfile, String) == """
                     const ROOTENV = "$(escape_string(ROOTENV))"
                     const MINICONDA_VERSION = "2"
                     const USE_MINIFORGE = $(CONDA_JL_USE_MINIFORGE_DEFAULT)
                     const CONDA_EXE = "$(escape_string(CONDA_EXE))"
                     """
-                end
             end
 
             # ROOTENV should be replaced since CONDA_JL_HOME wasn't explicitly set
             withenv("CONDA_JL_VERSION" => "3", "CONDA_JL_HOME" => nothing, "CONDA_JL_USE_MINIFORGE" => nothing, "CONDA_JL_CONDA_EXE" => nothing) do
                 Pkg.build("Conda")
-                let ROOTENV=joinpath(condadir, "3"), CONDA_EXE=default_conda_exe(ROOTENV)
+                local ROOTENV=joinpath(condadir, "3")
+                local CONDA_EXE=default_conda_exe(ROOTENV)
                 @test read(depsfile, String) == """
                     const ROOTENV = "$(escape_string(ROOTENV))"
                     const MINICONDA_VERSION = "3"
                     const USE_MINIFORGE = $(CONDA_JL_USE_MINIFORGE_DEFAULT)
                     const CONDA_EXE = "$(escape_string(CONDA_EXE))"
                     """
-                end
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,6 +71,7 @@ Conda.add("zlib", env; channel=alt_channel)
 
 @testset "Batch install and uninstall" begin
     mktempdir() do env
+        Conda.create(env)
         Conda.add(["affine", "ansi2html"], env)
         installed = Conda._installed_packages(env)
         @test "affine" ∈ installed
@@ -89,6 +90,7 @@ Conda.clean(; debug=true)
 @testset "Exporting and creating environments" begin
     mktempdir() do env
         new_env = :test_conda_jl_2
+        Conda.create(env)
         Conda.add("curl", env)
         Conda.export_list("conda-pkg.txt", env)
 


### PR DESCRIPTION
Here we introduce a new environment variable, `CONDA_JL_CONDA_EXE` which determines the location of the `conda` executable at build time. This in turn is saved in deps.jl as the constant `CONDA_EXE`. This in turn defines the constant `Conda.conda`. If `CONDA_EXE` does not exist due to an old deps.jl file, `Conda.conda` is defined in manner prior to this PR. 

The default `CONDA_EXE` is defined by the following code based on ROOTENV.
```julia
        const CONDA_EXE = if Sys.iswindows()
            p = joinpath(ROOTENV, "Script")
            conda_bat = joinpath(p, "conda.bat")
            isfile(conda_bat) ? conda_bat : joinpath(p, "conda.exe")
        else
            joinpath(ROOTENV, "bin", "conda")
        end
```

Conda.jl also has a method `_install_conda` which installs conda if the executable is not present. To determine the `PREFIX` for this installation the following code is used: `CONDA_EXE_PREFIX = conda |> dirname |> dirname`.



