### PR TITLE
remove `--source-cache` from conda clean

### DIFF
--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -375,7 +375,6 @@ function clean(;
         "--lock",
         "--tarballs",
         "--packages",
-        "--source-cache",
     ]
     cmd = Cmd([conda, "clean", "--yes", flags[kwargs]...])
     run(_set_conda_env(cmd))


### PR DESCRIPTION
`conda clean --source-cache` was deprecated in https://github.com/conda/conda/pull/7731, and now errors.