### PR TITLE
include Sys.ARCH in default rootenv

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -11,7 +11,7 @@ module DefaultDeps
         const MINICONDA_VERSION = "3"
     end
     if !isdefined(@__MODULE__, :ROOTENV)
-        const ROOTENV = joinpath(Main.condadir, MINICONDA_VERSION)
+        const ROOTENV = joinpath(Main.condadir, MINICONDA_VERSION, string(Sys.ARCH))
     end
 
     USE_MINIFORGE_DEFAULT = true


### PR DESCRIPTION
This is becoming important on e.g. MacOS where people commonly run both the ARM and x86_64 architectures on the same machine (the latter via Rosetta).