### PR TITLE
disable auto_update_conda

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -103,6 +103,8 @@ const CONDA_EXE = "$(escape_string(CONDA_EXE))"
 mkpath(condadir)
 mkpath(ROOTENV)
 
+write("$ROOTENV/condarc-julia.yml", "auto_update_conda: false")
+
 for depsfile in ("deps.jl", condadeps)
     if !isfile(depsfile) || read(depsfile, String) != deps
         write(depsfile, deps)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -103,8 +103,6 @@ const CONDA_EXE = "$(escape_string(CONDA_EXE))"
 mkpath(condadir)
 mkpath(ROOTENV)
 
-write("$ROOTENV/condarc-julia.yml", "auto_update_conda: false")
-
 for depsfile in ("deps.jl", condadeps)
     if !isfile(depsfile) || read(depsfile, String) != deps
         write(depsfile, deps)

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -227,7 +227,7 @@ https://github.com/JuliaPy/Conda.jl.
         if Sys.iswindows()
             run(Cmd(`$installer /S --no-shortcuts /NoRegistry=1 /AddToPath=0 /RegisterPython=0 /D=$PREFIX`, windows_verbatim=true))
         end
-        write("$PREFIX/condarc-julia.yml", "auto_update_conda: false")
+        write("$PREFIX/.condarc", "auto_update_conda: false")
     end
     if !isdir(prefix(env))
         create(env)

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -227,7 +227,7 @@ https://github.com/JuliaPy/Conda.jl.
         if Sys.iswindows()
             run(Cmd(`$installer /S --no-shortcuts /NoRegistry=1 /AddToPath=0 /RegisterPython=0 /D=$PREFIX`, windows_verbatim=true))
         end
-        write("$PREFIX/.condarc", "auto_update_conda: false")
+        write("$PREFIX/condarc-julia.yml", "auto_update_conda: false")
     end
     if !isdir(prefix(env))
         create(env)

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -227,6 +227,7 @@ https://github.com/JuliaPy/Conda.jl.
         if Sys.iswindows()
             run(Cmd(`$installer /S --no-shortcuts /NoRegistry=1 /AddToPath=0 /RegisterPython=0 /D=$PREFIX`, windows_verbatim=true))
         end
+        write("$PREFIX/condarc-julia.yml", "auto_update_conda: false")
     end
     if !isdir(prefix(env))
         create(env)


### PR DESCRIPTION
The motivations come from #242 and #238, where the error "ResolvePackageNotFound:   - conda==23.1.0" is thrown when conda automatically upgrades from 23.1.0 to 23.5.0. 

Although I did not quite understand the real logic of the error, one simple workaround is to disable the auto-update of conda, i.e., fix its version.

On the other hand, since the package Conda.jl has already required to install the latest conda release, 

https://github.com/JuliaPy/Conda.jl/blob/fe6c94c70609e6b6a8f853d72efc7d890df967e6/src/Conda.jl#L167-L179

I think the later update by `auto_update_conda` is just minor, like from 23.1.0 to 23.5.0, then disabling such minor aggressive updates should be reasonable. As a byproduct, it can save the upgrade time.