### PR TITLE
Fix the Order of Windows Installer Flags

### DIFF
--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -304,7 +304,7 @@ https://github.com/JuliaPy/Conda.jl.
             run(`$installer -b -f -p $PREFIX`)
         end
         if Sys.iswindows()
-            run(Cmd(`$installer /S /NoShortcuts=1 /NoRegistry=1 /AddToPath=0 /RegisterPython=0 /D=$PREFIX`, windows_verbatim=true))
+            run(Cmd(`$installer /NoShortcuts=1 /NoRegistry=1 /AddToPath=0 /RegisterPython=0 /S /D=$PREFIX`, windows_verbatim=true))
         end
         write("$PREFIX/condarc-julia.yml", "auto_update_conda: false")
     end


### PR DESCRIPTION
Following the documentation at https://conda.github.io/constructor/cli-options/#windows-installers, the `/S` flag should appear at the end.

The documentation:

![image](https://github.com/JuliaPy/Conda.jl/assets/7347975/f00c5a7e-37d5-4a7e-b5d4-e33d1d513089)


Pay attention to:

> You can also supply [standard NSIS flags](https://nsis.sourceforge.io/Docs/Chapter3.html#installerusage), but only after the ones mentioned above: