### PR TITLE
Disable satisfied-skip-solve on 32-bit linux

### DIFF
--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -329,12 +329,24 @@ function add(pkg::PkgOrPkgs, env::Environment=ROOTENV;
              args::Cmd = ``,
             )
     c = isempty(channel) ? `` : `-c $channel`
-    @static if Sys.iswindows() && Sys.WORD_SIZE == 32
+    @static if (Sys.iswindows() || Sys.islinux()) && Sys.WORD_SIZE == 32
         if satisfied_skip_solve
-            @warn """
-            The keyword satisfied_skip_solve was set to true,
-            but conda does not support --satisfied-skip-resolve on 32-bit Windows.
-            """
+            if Sys.iswindows()
+                @warn """
+                The keyword satisfied_skip_solve was set to true,
+                but conda does not support --satisfied-skip-resolve on 32-bit Windows.
+                """
+            else
+                # --satisfied-skip-solve flag was introduced in Conda 4.6.0
+                # https://docs.conda.io/projects/conda/en/latest/release-notes.html#version-4.6.0
+                # 32 bit builds on https://repo.anaconda.com/miniconda/ (where non-
+                # miniconda builds are by default sourced from) have not been updated since
+                # 4.5.12 for Linux-x86
+                @warn """
+                The keyword satisfied_skip_solve was set to true, but Conda builds for
+                32 bit are (by default) quite old and do not support --satisfied-skip-resolve.
+                """
+            end
         end
         S = ``
     else


### PR DESCRIPTION
**Motivation**: The default install of Conda on 32 bit linux uses pre-built binaries from repo.anaconda.com/miniconda; the 32 bit linux builds are very dated and do not support the --satisfied-skip-solve flag.

**Change**: Ignore / disable `satisfied_skip_solve` on 32 bit linux, in the same way it is ignored on windows (and add a linux-specific warning if it is set to true, as is the case in windows).

**Detail**:

The latest 32 bit linux build (https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86.sh) is 4.5.12, which pre-dates the introduction of --satisfied-skip-solve, which was introduced in 4.6.0 (https://docs.conda.io/projects/conda/en/latest/release-notes.html\#version-4.6.0).

This is a somewhat draconian approach, as someone could have a newer build of Conda on a 32 bit linux system (installed by some other means than the default Conda installer), and this change prevents them from using --satisfied-skip-solve.

Even so, I think this change is worthwhile because (a) the current state means a default install of PyCall (which sets this flag) on 32 bit linux fails (b) preventing --satisfied-skip-solve does not change correctness, just performance (I believe, I'm not an expert on conda) (c) there are probably not a lot of people hitting this code path (on 32 bit linux, with their own, newer, Conda).

An alternative would be to explicitly check the Conda version and if it is `<4.6.0 `, ignore `satisfied_skip_solve`. However, that seemed far more complex / a lot of extra code for little gain (again, given there isn't much cost to disabling satisfied-skip-solve for a likely small share of workflows)

**Reference**: #245 and github.com/JuliaPy/PyCall.jl/pull/1045