### PR TITLE
Use unique temp file for installer to fix multi-user collision

### DIFF
--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -287,14 +287,7 @@ https://github.com/JuliaPy/Conda.jl.
         end
 
         @info("Downloading miniconda installer ...")
-        INSTALLER_DIR = tempdir()
-        if Sys.isunix()
-            installer = joinpath(INSTALLER_DIR, "installer.sh")
-        end
-        if Sys.iswindows()
-            installer = joinpath(INSTALLER_DIR, "installer.exe")
-        end
-        mkpath(INSTALLER_DIR)
+        installer = tempname() * (Sys.iswindows() ? ".exe" : ".sh")
         Downloads.download(_installer_url(), installer)
 
         @info("Installing miniconda ...")


### PR DESCRIPTION
## Summary

- On multi-user systems, the hardcoded `/tmp/installer.sh` path causes `EPERM` errors when one user's leftover file blocks another user due to the sticky bit on `/tmp`
- Replace `joinpath(tempdir(), "installer.sh")` with `tempname()`, which generates a unique path per invocation and avoids the collision entirely

Fixes #253

## Test plan

- Verified the diff is minimal and preserves existing behavior (the installer path is only used locally within `_install_conda`)
- `tempname()` is a Julia stdlib function that returns a unique temporary file path, so no new dependencies are introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)